### PR TITLE
Allow to enable prometheus metrics without any annotations and viceversa

### DIFF
--- a/deploy/helm/trickster/templates/service.yaml
+++ b/deploy/helm/trickster/templates/service.yaml
@@ -1,12 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.service.annotations }}
+{{- if or .Values.service.annotations .Values.prometheusScrape }}
   annotations:
+  {{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+  {{- if .Values.prometheusScrape }}
     prometheus.io/scrape: {{ .Values.prometheusScrape | quote }}
     prometheus.io/port: {{ .Values.service.metricsPort | quote }}
     prometheus.io/path: /metrics
   {{- end }}
+{{- end }}
   name: {{ template "trickster.fullname" . }}
   labels:
     {{- include "trickster.labels" . | nindent 4 }}


### PR DESCRIPTION
At the moment, an annotation is needed in order to enable prometheus annotatios, as the section ```annotations``` is inside the ```if``` condition:
```
{{- if .Values.service.annotations }}
  annotations:
    prometheus.io/scrape: {{ .Values.prometheusScrape | quote }}
    prometheus.io/port: {{ .Values.service.metricsPort | quote }}
    prometheus.io/path: /metrics
  {{- end }}
```
The proposed change will allow enabling any annotations without enabling prometheus annotations and vice versa.