### PR TITLE
Helm service ports

### DIFF
--- a/deploy/helm/trickster/templates/service.yaml
+++ b/deploy/helm/trickster/templates/service.yaml
@@ -44,7 +44,7 @@ spec:
     {{- if .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
     {{- end }}
-    - name: metrics
+    - name: http-metrics
       port: {{ .Values.service.metricsPort }}
       protocol: TCP
       targetPort: metrics

--- a/deploy/helm/trickster/templates/service.yaml
+++ b/deploy/helm/trickster/templates/service.yaml
@@ -1,12 +1,17 @@
 apiVersion: v1
 kind: Service
 metadata:
-{{- if .Values.service.annotations }}
+{{- if or .Values.service.annotations .Values.prometheusScrape }}
   annotations:
+  {{- if .Values.service.annotations }}
+{{ toYaml .Values.service.annotations | indent 4 }}
+  {{- end }}
+  {{- if .Values.prometheusScrape }}
     prometheus.io/scrape: {{ .Values.prometheusScrape | quote }}
     prometheus.io/port: {{ .Values.service.metricsPort | quote }}
     prometheus.io/path: /metrics
   {{- end }}
+{{- end }}
   name: {{ template "trickster.fullname" . }}
   labels:
     {{- include "trickster.labels" . | nindent 4 }}


### PR DESCRIPTION
Istio supports proxying all TCP traffic by default, but in order to provide additional capabilities, such as routing and rich metrics, the protocol must be determined.

https://istio.io/docs/ops/configuration/traffic-management/protocol-selection/