### PR TITLE
Fix indentation in configmap for tracing section

### DIFF
--- a/deploy/helm/trickster/Chart.yaml
+++ b/deploy/helm/trickster/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.0.0
 description: Trickster is a reverse proxy cache for the Prometheus HTTP API that dramatically accelerates chart rendering times for any series queried from Prometheus.
 name: trickster
-version: 1.4.1
+version: 1.4.2
 home: https://github.com/Comcast/trickster
 icon: https://github.com/Comcast/trickster/blob/master/docs/images/logos/trickster-horizontal-sm.png?raw=true
 sources:

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -363,18 +363,18 @@ data:
       {{- range .Values.tracing }}
       
       {{ printf "[tracing.%s]" .name }}
-          {{- if .implementation }}
-        implementation = {{ .implementation | quote }}
-          {{- end }}
-          {{- if .exporter }}
-        exporter = {{ .exporter | quote }}
-          {{- end }}
-          {{- if .collector }}
-        collector = {{ .collector | quote }}
-          {{- end }}
-          {{- if .sampleRate }}
-        sample_rate = {{ .sampleRate }}
-          {{- end }}
+        {{- if .implementation }}
+      implementation = {{ .implementation | quote }}
+        {{- end }}
+        {{- if .exporter }}
+      exporter = {{ .exporter | quote }}
+        {{- end }}
+        {{- if .collector }}
+      collector = {{ .collector | quote }}
+        {{- end }}
+        {{- if .sampleRate }}
+      sample_rate = {{ .sampleRate }}
+        {{- end }}
       {{- end }}
 
     {{- if .Values.service.metricsPort }}

--- a/deploy/helm/trickster/templates/configmap.yaml
+++ b/deploy/helm/trickster/templates/configmap.yaml
@@ -363,18 +363,18 @@ data:
       {{- range .Values.tracing }}
       
       {{ printf "[tracing.%s]" .name }}
-            {{- if .implementation }}
-          implementation = {{ .implementation | quote }}
-            {{- end }}
-            {{- if .exporter }}
-          exporter = {{ .exporter | quote }}
-            {{- end }}
-            {{- if .collector }}
-          collector = {{ .collector | quote }}
-            {{- end }}
-            {{- if .sampleRate }}
-          sample_rate = {{ .sampleRate }}
-            {{- end }}
+          {{- if .implementation }}
+        implementation = {{ .implementation | quote }}
+          {{- end }}
+          {{- if .exporter }}
+        exporter = {{ .exporter | quote }}
+          {{- end }}
+          {{- if .collector }}
+        collector = {{ .collector | quote }}
+          {{- end }}
+          {{- if .sampleRate }}
+        sample_rate = {{ .sampleRate }}
+          {{- end }}
       {{- end }}
 
     {{- if .Values.service.metricsPort }}


### PR DESCRIPTION
Indentation for tracing section in helm configmap is wrong, so configmap fails when using the same.