### PR TITLE
V1.0.3 bugfix

### DIFF
--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -44,7 +44,7 @@ var (
 
 const (
 	applicationName    = "trickster"
-	applicationVersion = "1.0.2"
+	applicationVersion = "1.0.3"
 )
 
 // Package main is the main package for the Trickster application

--- a/internal/cache/badger/badger.go
+++ b/internal/cache/badger/badger.go
@@ -102,7 +102,7 @@ func (c *Cache) Remove(cacheKey string) {
 }
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Badger
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	log.Debug("badger cache bulk remove", log.Pairs{})
 
 	c.dbh.Update(func(txn *badger.Txn) error {

--- a/internal/cache/badger/badger_test.go
+++ b/internal/cache/badger/badger_test.go
@@ -161,8 +161,8 @@ func TestBadgerCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	bc.BulkRemove([]string{""}, true)
-	bc.BulkRemove([]string{cacheKey}, true)
+	bc.BulkRemove([]string{""})
+	bc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = bc.Retrieve(cacheKey, false)

--- a/internal/cache/bbolt/bbolt.go
+++ b/internal/cache/bbolt/bbolt.go
@@ -159,7 +159,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) ([]byte
 	if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
 		log.Debug("bbolt cache retrieve", log.Pairs{"cacheKey": cacheKey})
 		if atime {
-			c.Index.UpdateObjectAccessTime(cacheKey)
+			go c.Index.UpdateObjectAccessTime(cacheKey)
 		}
 		cache.ObserveCacheOperation(c.Name, c.Config.CacheType, "get", "hit", float64(len(data)))
 		locks.Release(lockPrefix + cacheKey)

--- a/internal/cache/bbolt/bbolt_test.go
+++ b/internal/cache/bbolt/bbolt_test.go
@@ -414,7 +414,7 @@ func TestBboltCache_BulkRemove(t *testing.T) {
 	if ls != status.LookupStatusHit {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
-	bc.BulkRemove([]string{cacheKey}, true)
+	bc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = bc.Retrieve(cacheKey, false)
@@ -436,7 +436,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
 	}
 
-	bc.BulkRemove(keyArray, true)
+	bc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -36,7 +36,7 @@ type Cache interface {
 	Retrieve(cacheKey string, allowExpired bool) ([]byte, status.LookupStatus, error)
 	SetTTL(cacheKey string, ttl time.Duration)
 	Remove(cacheKey string)
-	BulkRemove(cacheKeys []string, noLock bool)
+	BulkRemove(cacheKeys []string)
 	Close() error
 	Configuration() *config.CachingConfig
 }
@@ -49,7 +49,7 @@ type MemoryCache interface {
 	Retrieve(cacheKey string, allowExpired bool) ([]byte, status.LookupStatus, error)
 	SetTTL(cacheKey string, ttl time.Duration)
 	Remove(cacheKey string)
-	BulkRemove(cacheKeys []string, noLock bool)
+	BulkRemove(cacheKeys []string)
 	Close() error
 	Configuration() *config.CachingConfig
 	StoreReference(cacheKey string, data ReferenceObject, ttl time.Duration) error

--- a/internal/cache/filesystem/filesystem.go
+++ b/internal/cache/filesystem/filesystem.go
@@ -163,18 +163,18 @@ func (c *Cache) Remove(cacheKey string) {
 	locks.Release(lockPrefix + cacheKey)
 }
 
-func (c *Cache) remove(cacheKey string, noLock bool) {
+func (c *Cache) remove(cacheKey string, isBulk bool) {
 
-	if err := os.Remove(c.getFileName(cacheKey)); err == nil {
-		c.Index.RemoveObject(cacheKey, noLock)
+	if err := os.Remove(c.getFileName(cacheKey)); err == nil && !isBulk {
+		c.Index.RemoveObject(cacheKey)
 	}
 	cache.ObserveCacheDel(c.Name, c.Config.CacheType, 0)
 }
 
 // BulkRemove removes a list of objects from the cache
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	for _, cacheKey := range cacheKeys {
-		c.remove(cacheKey, noLock)
+		c.remove(cacheKey, true)
 	}
 }
 

--- a/internal/cache/filesystem/filesystem.go
+++ b/internal/cache/filesystem/filesystem.go
@@ -138,7 +138,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) ([]byte
 	if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
 		log.Debug("filesystem cache retrieve", log.Pairs{"key": cacheKey, "dataFile": dataFile})
 		if atime {
-			c.Index.UpdateObjectAccessTime(cacheKey)
+			go c.Index.UpdateObjectAccessTime(cacheKey)
 		}
 		cache.ObserveCacheOperation(c.Name, c.Config.CacheType, "get", "hit", float64(len(data)))
 		locks.Release(lockPrefix + cacheKey)

--- a/internal/cache/filesystem/filesystem_test.go
+++ b/internal/cache/filesystem/filesystem_test.go
@@ -570,7 +570,7 @@ func TestFilesystemCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	fc.BulkRemove([]string{cacheKey}, true)
+	fc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = fc.Retrieve(cacheKey, false)
@@ -591,7 +591,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
 	}
 
-	fc.BulkRemove(keyArray, true)
+	fc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/internal/cache/index/index.go
+++ b/internal/cache/index/index.go
@@ -288,7 +288,7 @@ func (idx *Index) reap() {
 
 	if len(removals) > 0 {
 		cache.ObserveCacheEvent(idx.name, idx.cacheType, "eviction", "ttl")
-		idx.bulkRemoveFunc(removals)
+		go idx.bulkRemoveFunc(removals)
 		idx.RemoveObjects(removals, true)
 		cacheChanged = true
 	}
@@ -345,7 +345,7 @@ func (idx *Index) reap() {
 
 		if len(removals) > 0 {
 			cache.ObserveCacheEvent(idx.name, idx.cacheType, "eviction", evictionType)
-			idx.bulkRemoveFunc(removals)
+			go idx.bulkRemoveFunc(removals)
 			idx.RemoveObjects(removals, true)
 			cacheChanged = true
 		}

--- a/internal/cache/index/index_test.go
+++ b/internal/cache/index/index_test.go
@@ -28,10 +28,7 @@ func init() {
 
 var testBulkIndex *Index
 
-func testBulkRemoveFunc(cacheKeys []string, noLock bool) {
-	for _, cacheKey := range cacheKeys {
-		testBulkIndex.RemoveObject(cacheKey, noLock)
-	}
+func testBulkRemoveFunc(cacheKeys []string) {
 }
 func fakeFlusherFunc(string, []byte) {}
 
@@ -219,7 +216,7 @@ func TestRemoveObject(t *testing.T) {
 		t.Errorf("test object missing from index")
 	}
 
-	idx.RemoveObject("test", false)
+	idx.RemoveObject("test")
 	if _, ok := idx.Objects["test"]; ok {
 		t.Errorf("test object should be missing from index")
 	}

--- a/internal/cache/memory/memory.go
+++ b/internal/cache/memory/memory.go
@@ -129,7 +129,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) (*index
 		if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
 			log.Debug("memory cache retrieve", log.Pairs{"cacheKey": cacheKey})
 			if atime {
-				c.Index.UpdateObjectAccessTime(cacheKey)
+				go c.Index.UpdateObjectAccessTime(cacheKey)
 			}
 			cache.ObserveCacheOperation(c.Name, c.Config.CacheType, "get", "hit", float64(len(o.Value)))
 			locks.Release(lockPrefix + cacheKey)

--- a/internal/cache/memory/memory_test.go
+++ b/internal/cache/memory/memory_test.go
@@ -348,7 +348,7 @@ func TestCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	mc.BulkRemove([]string{cacheKey}, true)
+	mc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = mc.Retrieve(cacheKey, false)
@@ -369,7 +369,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 
 	mc := storeBenchmark(b)
 
-	mc.BulkRemove(keyArray, true)
+	mc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/internal/cache/redis/redis.go
+++ b/internal/cache/redis/redis.go
@@ -119,7 +119,7 @@ func (c *Cache) SetTTL(cacheKey string, ttl time.Duration) {
 }
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Redis
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	log.Debug("redis cache bulk remove", log.Pairs{})
 	c.client.Del(cacheKeys...)
 	cache.ObserveCacheDel(c.Name, c.Config.CacheType, float64(len(cacheKeys)))

--- a/internal/cache/redis/redis_test.go
+++ b/internal/cache/redis/redis_test.go
@@ -483,7 +483,7 @@ func TestCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	rc.BulkRemove([]string{cacheKey}, true)
+	rc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = rc.Retrieve(cacheKey, false)
@@ -504,7 +504,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
 	}
 
-	rc.BulkRemove(keyArray, true)
+	rc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/internal/proxy/engines/cache_test.go
+++ b/internal/proxy/engines/cache_test.go
@@ -451,8 +451,8 @@ func (tc *testCache) Retrieve(cacheKey string, allowExpired bool) ([]byte, statu
 	return nil, status.LookupStatusError, errTest
 }
 
-func (tc *testCache) SetTTL(cacheKey string, ttl time.Duration)  {}
-func (tc *testCache) Remove(cacheKey string)                     {}
-func (tc *testCache) BulkRemove(cacheKeys []string, noLock bool) {}
-func (tc *testCache) Close() error                               { return errTest }
-func (tc *testCache) Configuration() *config.CachingConfig       { return tc.configuration }
+func (tc *testCache) SetTTL(cacheKey string, ttl time.Duration) {}
+func (tc *testCache) Remove(cacheKey string)                    {}
+func (tc *testCache) BulkRemove(cacheKeys []string)             {}
+func (tc *testCache) Close() error                              { return errTest }
+func (tc *testCache) Configuration() *config.CachingConfig      { return tc.configuration }

--- a/internal/proxy/engines/client_test.go
+++ b/internal/proxy/engines/client_test.go
@@ -756,9 +756,6 @@ func (c *TestClient) HealthHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *TestClient) QueryRangeHandler(w http.ResponseWriter, r *http.Request) {
-
-	//rsc := request.NewResources(c.config, c.path
-
 	r.URL = c.BuildUpstreamURL(r)
 	DeltaProxyCacheRequest(w, r)
 }

--- a/internal/proxy/engines/deltaproxycache.go
+++ b/internal/proxy/engines/deltaproxycache.go
@@ -343,7 +343,6 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 				} else {
 					cdata, err := client.MarshalTimeseries(cts)
 					if err != nil {
-						locks.Release(key)
 						return
 					}
 					doc.Body = cdata

--- a/internal/proxy/engines/deltaproxycache.go
+++ b/internal/proxy/engines/deltaproxycache.go
@@ -91,7 +91,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	client.SetExtent(r, trq, &trq.Extent)
+	client.SetExtent(pr.upstreamRequest, trq, &trq.Extent)
 	key := oc.CacheKeyPrefix + "." + pr.DeriveCacheKey(trq.TemplateURL, "")
 
 	locks.Acquire(key)
@@ -229,7 +229,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 		go func(e *timeseries.Extent, rq *proxyRequest) {
 			defer wg.Done()
 			rq.Request = rq.WithContext(tctx.WithResources(r.Context(), request.NewResources(oc, pc, cc, cache, client)))
-			client.SetExtent(rq.Request, trq, e)
+			client.SetExtent(rq.upstreamRequest, trq, e)
 			body, resp, _ := rq.Fetch()
 			if resp.StatusCode == http.StatusOK && len(body) > 0 {
 				nts, err := client.UnmarshalTimeseries(body)

--- a/internal/proxy/engines/proxy_request.go
+++ b/internal/proxy/engines/proxy_request.go
@@ -92,7 +92,7 @@ func (pr *proxyRequest) Clone() *proxyRequest {
 	return &proxyRequest{
 		Request: pr.Request.Clone(context.Background()),
 		upstreamRequest: pr.upstreamRequest.
-			Clone(tctx.WithResources(pr.upstreamRequest.Context(), rsc)),
+			Clone(tctx.WithResources(context.Background(), rsc)),
 		cacheDocument:      pr.cacheDocument,
 		key:                pr.key,
 		cacheStatus:        pr.cacheStatus,

--- a/pkg/locks/locks.go
+++ b/pkg/locks/locks.go
@@ -16,6 +16,7 @@
 package locks
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -23,53 +24,56 @@ var locks = make(map[string]*namedLock)
 var mapLock = sync.Mutex{}
 
 type namedLock struct {
+	*sync.Mutex
 	name      string
-	mtx       *sync.Mutex
 	queueSize int
 }
 
 func newNamedLock(name string) *namedLock {
 	return &namedLock{
-		name: name,
-		mtx:  &sync.Mutex{},
+		name:  name,
+		Mutex: &sync.Mutex{},
 	}
 }
 
 // Acquire returns a named lock, and blocks until it is acquired
-func Acquire(lockName string) *sync.Mutex {
-
-	var nl *namedLock
-	var ok bool
+func Acquire(lockName string) error {
 
 	if lockName == "" {
-		return nil
+		return fmt.Errorf("invalid lock name: %s", lockName)
 	}
 
 	mapLock.Lock()
-	if nl, ok = locks[lockName]; !ok {
+	nl, ok := locks[lockName]
+	if !ok {
 		nl = newNamedLock(lockName)
 		locks[lockName] = nl
 	}
 	nl.queueSize++
 	mapLock.Unlock()
-	nl.mtx.Lock()
-	return nl.mtx
+
+	nl.Lock()
+	return nil
 }
 
 // Release unlocks and releases a named lock
-func Release(lockName string) {
+func Release(lockName string) error {
 
 	if lockName == "" {
-		return
+		return fmt.Errorf("invalid lock name: %s", lockName)
 	}
 
 	mapLock.Lock()
-	if nl, ok := locks[lockName]; ok {
+	nl, ok := locks[lockName]
+	if ok {
 		nl.queueSize--
 		if nl.queueSize == 0 {
 			delete(locks, lockName)
 		}
-		nl.mtx.Unlock()
+		mapLock.Unlock()
+		nl.Unlock()
+		return nil
 	}
 	mapLock.Unlock()
+	return fmt.Errorf("no such lock name: %s", lockName)
 }

--- a/pkg/locks/locks.go
+++ b/pkg/locks/locks.go
@@ -64,8 +64,7 @@ func Release(lockName string) error {
 	}
 
 	mapLock.Lock()
-	nl, ok := locks[lockName]
-	if ok {
+	if nl, ok := locks[lockName]; ok {
 		nl.queueSize--
 		if nl.queueSize == 0 {
 			delete(locks, lockName)


### PR DESCRIPTION
This addresses 2 separate issues:
- Mitigate mutex deadlocks leading to too many open files #391, #397 
- Fix "context canceled" and false flag "502 Bad Gateway" errors when downstream clients cancel a request.