### PR TITLE
support config reload

### DIFF
--- a/cmd/trickster/conf/example.conf
+++ b/cmd/trickster/conf/example.conf
@@ -493,10 +493,31 @@ listen_port = 8480
 ## Configuration Options for Metrics Instrumentation
 # [metrics]
 ## listen_port defines the port that Trickster's metrics server listens on at /metrics
+## 8481 is the default
 # listen_port = 8481
 ## listen_address defines the ip that Trickster's metrics server listens on at /metrics
 ## empty by default, listening on all interfaces
 # listen_address = ''
+
+## Configuration Options for Config Reloading
+# [reloading]
+## listen_port defines the port where Trickster's config reload server listens
+## 8484 is the default 
+# listen_port = 8484
+## listen_address defines the ip where Trickster's config reload server listens
+## empty by default, listening on all interfaces
+# listen_address = ''
+## handler_path defines the HTTP path where the Reload interface is available.
+## by default, this is '/trickster/config/reload'
+# handler_path = '/trickster/config/reload'
+## bleed_timeout_secs defines how long old HTTP listeners will live to allow
+## outstanding connection to close organically, before the listener is forcefully closed
+## the default is 30
+# bleed_timeout_secs = 30
+## rate_limit_secs specifies the rate limit timeout duration to apply to the HTTP reload interface.
+## The reload interface is disabled for this duration of time whenever a config reload request is
+## made that fails because the underlying config file is unmodified. default is 3
+# rate_limit_secs = 3
 
 ## Configuration Options for Logging Instrumentation
 # [logging]

--- a/cmd/trickster/conf/example.conf
+++ b/cmd/trickster/conf/example.conf
@@ -510,10 +510,10 @@ listen_port = 8480
 ## handler_path defines the HTTP path where the Reload interface is available.
 ## by default, this is '/trickster/config/reload'
 # handler_path = '/trickster/config/reload'
-## bleed_timeout_secs defines how long old HTTP listeners will live to allow
+## drain_timeout_secs defines how long old HTTP listeners will live to allow
 ## outstanding connection to close organically, before the listener is forcefully closed
 ## the default is 30
-# bleed_timeout_secs = 30
+# drain_timeout_secs = 30
 ## rate_limit_secs specifies the rate limit timeout duration to apply to the HTTP reload interface.
 ## The reload interface is disabled for this duration of time whenever a config reload request is
 ## made that fails because the underlying config file is unmodified. default is 3

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -162,7 +162,7 @@ func applyLoggingConfig(c, oc *config.Config, oldLog *log.Logger) *log.Logger {
 				// if we're changing from file1 -> console or file1 -> file2, close file1 handle
 				// the extra 1s allows HTTP listeners to close first and finish their log writes
 				go delayedLogCloser(oldLog,
-					time.Duration(c.ReloadConfig.BleedTimeoutSecs+1)*time.Second)
+					time.Duration(c.ReloadConfig.DrainTimeoutSecs+1)*time.Second)
 			}
 			return initLogger(c)
 		}
@@ -246,7 +246,7 @@ func initLogger(c *config.Config) *log.Logger {
 func delayedLogCloser(log *log.Logger, delay time.Duration) {
 	// we can't immediately close the log, because some outstanding
 	// http requests might still be on the old reference, so this will
-	// allow time for those connections to bleed off
+	// allow time for those connections to drain
 	if log == nil {
 		return
 	}

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -120,10 +120,6 @@ func applyConfig(conf, oldConf *config.Config, wg *sync.WaitGroup,
 	router.HandleFunc(conf.Main.ConfigHandlerPath, th.ConfigHandleFunc(conf)).Methods(http.MethodGet)
 
 	rh := handlers.ReloadHandleFunc(runConfig, conf, wg, log, args)
-	if conf.ReloadConfig.FrontendRouting {
-		// add Config Reload HTTP Handler
-		router.HandleFunc(conf.ReloadConfig.HandlerPath, rh).Methods(http.MethodGet)
-	}
 
 	var caches = applyCachingConfig(conf, oldConf, log, nil)
 

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -135,8 +135,8 @@ func applyConfig(conf, oldConf *config.Config, wg *sync.WaitGroup, log *log.Logg
 	metrics.LastReloadSuccessfulTimestamp.Set(float64(time.Now().Unix()))
 	metrics.LastReloadSuccessful.Set(1)
 	// add Config Reload HUP Signal Monitor
-	if oldConf != nil {
-		oldConf.QuitChan <- true // this signals the old hup monitor goroutine to exit
+	if oldConf != nil && oldConf.Resources != nil {
+		oldConf.Resources.QuitChan <- true // this signals the old hup monitor goroutine to exit
 	}
 	startHupMonitor(conf, wg, log, caches, args)
 }

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -187,14 +187,11 @@ func applyCachingConfig(c, oc *config.Config, logger *log.Logger,
 	caches := make(map[string]cache.Cache)
 
 	if oc == nil || oldCaches == nil {
-		fmt.Println("Caches load")
 		for k, v := range c.Caches {
 			caches[k] = registration.NewCache(k, v, logger)
 		}
 		return caches
 	}
-
-	fmt.Println("CACHE STUFF")
 
 	for k, v := range c.Caches {
 
@@ -205,7 +202,6 @@ func applyCachingConfig(c, oc *config.Config, logger *log.Logger,
 			// if a cache is in both the old and new config, and unchanged, pass the
 			// pre-existing object instead of making a new one
 			if v.Equal(ocfg) {
-				fmt.Println("PASS ALONG")
 				caches[k] = w
 				continue
 			}
@@ -216,7 +212,6 @@ func applyCachingConfig(c, oc *config.Config, logger *log.Logger,
 			// then add the old cache with the new index config to the new cache map
 			if ocfg.CacheTypeID == v.CacheTypeID &&
 				ocfg.CacheTypeID == types.CacheTypeMemory {
-				fmt.Println("MEMORY YO")
 				if v.Index != nil {
 					mc := w.(*memory.Cache)
 					mc.Index.UpdateOptions(v.Index)

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/tricksterproxy/trickster/pkg/cache"
+	"github.com/tricksterproxy/trickster/pkg/cache/registration"
+	"github.com/tricksterproxy/trickster/pkg/config"
+	th "github.com/tricksterproxy/trickster/pkg/proxy/handlers"
+	"github.com/tricksterproxy/trickster/pkg/routing"
+	"github.com/tricksterproxy/trickster/pkg/runtime"
+	"github.com/tricksterproxy/trickster/pkg/util/log"
+	tl "github.com/tricksterproxy/trickster/pkg/util/log"
+	"github.com/tricksterproxy/trickster/pkg/util/metrics"
+	tr "github.com/tricksterproxy/trickster/pkg/util/tracing/registration"
+)
+
+var cfgLock = &sync.Mutex{}
+
+func runConfig(oldConf *config.Config, wg *sync.WaitGroup,
+	log *log.Logger, args []string, errorsFatal bool) {
+
+	cfgLock.Lock()
+	defer cfgLock.Unlock()
+	var err error
+
+	// load the config
+	conf, flags, err := config.Load(runtime.ApplicationName, runtime.ApplicationVersion, args)
+	if err != nil {
+		fmt.Println("\nERROR: Could not load configuration:", err.Error())
+		if flags != nil && !flags.ValidateConfig {
+			PrintUsage()
+		}
+		handleStartupIssue("", nil, nil, errorsFatal)
+		return
+	}
+
+	// if it's a -version command, print version and exit
+	if flags.PrintVersion {
+		PrintVersion()
+		os.Exit(0)
+	}
+
+	err = validateConfig(conf)
+	if err != nil {
+		handleStartupIssue("ERROR: Could not load configuration: "+err.Error(), nil, nil, errorsFatal)
+	}
+	if flags.ValidateConfig {
+		fmt.Println("Trickster configuration validation succeeded.")
+		os.Exit(0)
+	}
+
+	applyConfig(conf, oldConf, wg, log, args, errorsFatal)
+
+}
+
+func applyConfig(conf, oldConf *config.Config, wg *sync.WaitGroup,
+	log *log.Logger, args []string, errorsFatal bool) {
+
+	log = applyLoggingConfig(conf, oldConf, log)
+
+	for _, w := range conf.LoaderWarnings {
+		log.Warn(w, tl.Pairs{})
+	}
+
+	// TODO: move to function and  handle differences
+	//Register Tracing Configurations
+	tracerFlushers, err := tr.RegisterAll(conf, log)
+	if err != nil {
+		handleStartupIssue("tracing registration failed", tl.Pairs{"detail": err.Error()},
+			log, errorsFatal)
+		return
+	}
+
+	if len(tracerFlushers) > 0 {
+		for _, f := range tracerFlushers {
+			// TODO: Move elsewhere
+			defer f()
+		}
+	}
+
+	// every config reload is a new router
+	router := mux.NewRouter()
+	router.HandleFunc(conf.Main.PingHandlerPath, th.PingHandleFunc(conf)).Methods("GET")
+	router.HandleFunc(conf.Main.ConfigHandlerPath, th.ConfigHandleFunc(conf)).Methods("GET")
+	// TODO: Add Reload Handler w/ Relevant stuff (incl. this func)
+
+	// TODO: Validate if anything about the caches has changed (e.g., are more than one cache using same filename)
+	// has the filename moved from and old to a new config - and if so, can we keep that handle.
+	var caches = make(map[string]cache.Cache)
+	for k, v := range conf.Caches {
+		c := registration.NewCache(k, v, log)
+		caches[k] = c
+	}
+
+	_, err = routing.RegisterProxyRoutes(conf, router, caches, log, false)
+	if err != nil {
+		handleStartupIssue("route registration failed", tl.Pairs{"detail": err.Error()},
+			log, errorsFatal)
+		return
+	}
+
+	// TODO: Validate if the ports or addresses have changed and adjust
+	//
+	// if TLS port is configured and at least one origin is mapped to a good tls config,
+	// then set up the tls server listener instance
+	if conf.Frontend.ServeTLS && conf.Frontend.TLSListenPort > 0 {
+		var tlsConfig *tls.Config
+		tlsConfig, err = conf.TLSCertConfig()
+		if err != nil {
+			log.Error("unable to start tls listener due to certificate error", tl.Pairs{"detail": err})
+		} else {
+			wg.Add(1)
+			go startListener("tlsListener",
+				conf.Frontend.TLSListenAddress, conf.Frontend.TLSListenPort,
+				conf.Frontend.ConnectionsLimit, tlsConfig, router, wg, true, log)
+		}
+	}
+
+	// if the plaintext HTTP port is configured, then set up the http listener instance
+	if conf.Frontend.ListenPort > 0 {
+		wg.Add(1)
+		go startListener("httpListener",
+			conf.Frontend.ListenAddress, conf.Frontend.ListenPort,
+			conf.Frontend.ConnectionsLimit, nil, router, wg, true, log)
+	}
+
+	// if the Metrics HTTP port is configured, then set up the http listener instance
+	if conf.Metrics != nil && conf.Metrics.ListenPort > 0 {
+		wg.Add(1)
+		go startListenerRouter("metricsListener",
+			conf.Metrics.ListenAddress, conf.Metrics.ListenPort,
+			conf.Frontend.ConnectionsLimit, nil, "/metrics", metrics.Handler(), wg, true, log)
+	}
+
+}
+
+func applyLoggingConfig(c, oc *config.Config, oldLog *log.Logger) *log.Logger {
+
+	if c == nil || c.Logging == nil {
+		return oldLog
+	}
+
+	if oc != nil && oc.Logging != nil {
+		if c.Logging.LogFile == oc.Logging.LogFile &&
+			c.Logging.LogLevel == oc.Logging.LogLevel {
+			// no changes in logging config,
+			// so we keep the old logger intact
+			return oldLog
+		}
+		if c.Logging.LogFile != oc.Logging.LogFile {
+			if oc.Logging.LogFile != "" {
+				// if we're changing from file1 -> console or file1 -> file2, close file1 handle
+				go delayedLogCloser(oldLog)
+			}
+			return initLogger(c)
+		}
+		if c.Logging.LogLevel != oc.Logging.LogLevel {
+			// the only change is the log level, so update it and return the original logger
+			oldLog.SetLogLevel(c.Logging.LogLevel)
+			return oldLog
+		}
+	}
+
+	return initLogger(c)
+}
+
+func initLogger(c *config.Config) *log.Logger {
+	log := tl.New(c)
+	log.Info("application loaded from configuration",
+		tl.Pairs{
+			"name":      runtime.ApplicationName,
+			"version":   runtime.ApplicationVersion,
+			"goVersion": applicationGoVersion,
+			"goArch":    applicationGoArch,
+			"commitID":  applicationGitCommitID,
+			"buildTime": applicationBuildTime,
+			"logLevel":  c.Logging.LogLevel,
+			"config":    c.Main.ConfigFilePath,
+		},
+	)
+	return log
+}
+
+func delayedLogCloser(log *log.Logger) {
+	// we can't immediately close the log, because some outstanding
+	// http requests might still be on the old reference, so this will
+	// allow time for those connections to bleed off
+	if log == nil {
+		return
+	}
+	time.Sleep(time.Second * 30)
+	log.Close()
+}
+
+func handleStartupIssue(event string, detail log.Pairs, logger *log.Logger, exitFatal bool) {
+	if event != "" {
+		if logger != nil {
+			if exitFatal {
+				logger.Fatal(1, event, detail)
+				return
+			}
+			logger.Error(event, detail)
+			return
+		}
+		fmt.Println(event)
+	}
+	if exitFatal {
+		os.Exit(1)
+	}
+}
+
+func validateConfig(conf *config.Config) error {
+
+	for _, w := range conf.LoaderWarnings {
+		fmt.Println(w)
+	}
+
+	// TODO: Tracers w/ Dry Run
+
+	var caches = make(map[string]cache.Cache)
+	for k := range conf.Caches {
+		caches[k] = nil
+	}
+
+	router := mux.NewRouter()
+	log := log.ConsoleLogger(conf.Logging.LogLevel)
+	_, err := routing.RegisterProxyRoutes(conf, router, caches, log, false)
+	if err != nil {
+		return err
+	}
+
+	if conf.Frontend.TLSListenPort < 1 && conf.Frontend.ListenPort < 1 {
+		return errors.New("no http or https listeners configured")
+	}
+
+	if conf.Frontend.ServeTLS && conf.Frontend.TLSListenPort > 0 {
+		_, err = conf.TLSCertConfig()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -118,7 +118,6 @@ func applyConfig(conf, oldConf *config.Config, wg *sync.WaitGroup, log *log.Logg
 	// every config (re)load is a new router
 	router := mux.NewRouter()
 	router.HandleFunc(conf.Main.PingHandlerPath, th.PingHandleFunc(conf)).Methods(http.MethodGet)
-	router.HandleFunc(conf.Main.ConfigHandlerPath, th.ConfigHandleFunc(conf)).Methods(http.MethodGet)
 
 	var caches = applyCachingConfig(conf, oldConf, log, oldCaches)
 	rh := handlers.ReloadHandleFunc(runConfig, conf, wg, log, caches, args)

--- a/cmd/trickster/listeners.go
+++ b/cmd/trickster/listeners.go
@@ -45,14 +45,14 @@ func startListener(listenerName, address string, port int, connectionsLimit int,
 		}
 		return err
 	}
-	log.Info("proxy listener starting",
+	log.Info("http listener starting",
 		tl.Pairs{"name": listenerName, "port": port, "address": address})
 
 	listeners[listenerName] = l
 
 	err = http.Serve(l, handlers.CompressHandler(router))
 	if err != nil {
-		log.Error("listener stopping", tl.Pairs{"name": listenerName, "detail": err})
+		log.Error("http listener stopping", tl.Pairs{"name": listenerName, "detail": err})
 		if exitOnError {
 			// TODO: don't exit when it's a graceful stop
 			os.Exit(1)

--- a/cmd/trickster/listeners.go
+++ b/cmd/trickster/listeners.go
@@ -118,11 +118,18 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		oldConf.Frontend != nil && oldConf.Frontend.Equal(conf.Frontend) {
 		updateRouters(router, adminRouter)
 		if TLSOptionsChanged(conf, oldConf) {
-			tlsConfig, err = conf.TLSCertConfig()
+			tlsConfig, _ = conf.TLSCertConfig()
 			if lg, ok := listeners["tlsListener"]; ok && lg != nil && lg.tlsSwapper != nil {
 				lg.tlsSwapper.SetCerts(tlsConfig.Certificates)
 			}
 		}
+		return
+	}
+
+	if oldConf != nil && oldConf.Frontend.ConnectionsLimit != conf.Frontend.ConnectionsLimit {
+		log.Warn("connections limit change requires a process restart. listeners not updated.",
+			tl.Pairs{"oldLimit": oldConf.Frontend.ConnectionsLimit,
+				"newLimit": conf.Frontend.ConnectionsLimit})
 		return
 	}
 

--- a/cmd/trickster/listeners.go
+++ b/cmd/trickster/listeners.go
@@ -56,9 +56,7 @@ func startListener(listenerName, address string, port int, connectionsLimit int,
 	lg := &listenerGroup{routeSwapper: ph.NewSwitchHandler(router), exitOnError: exitOnError}
 	if tlsConfig != nil && len(tlsConfig.Certificates) > 0 {
 		lg.tlsConfig = tlsConfig
-		lg.tlsSwapper = &sw.CertSwapper{
-			Certificates: tlsConfig.Certificates,
-		}
+		lg.tlsSwapper = sw.NewSwapper(tlsConfig.Certificates)
 
 		// Replace the normal GetCertificate function in the TLS config with lg.tlsSwapper's,
 		// so users swap certs in the config later without restarting the entire process

--- a/cmd/trickster/listeners.go
+++ b/cmd/trickster/listeners.go
@@ -33,7 +33,7 @@ var listeners = make(map[string]net.Listener)
 
 func startListener(listenerName, address string, port int, connectionsLimit int,
 	tlsConfig *tls.Config, router http.Handler, wg *sync.WaitGroup,
-	exitOnError bool, log *tl.TricksterLogger) error {
+	exitOnError bool, log *tl.Logger) error {
 	if wg != nil {
 		defer wg.Done()
 	}
@@ -63,7 +63,7 @@ func startListener(listenerName, address string, port int, connectionsLimit int,
 
 func startListenerRouter(listenerName, address string, port int, connectionsLimit int,
 	tlsConfig *tls.Config, path string, handler http.Handler, wg *sync.WaitGroup,
-	exitOnError bool, log *tl.TricksterLogger) error {
+	exitOnError bool, log *tl.Logger) error {
 	router := http.NewServeMux()
 	router.Handle(path, handler)
 	return startListener(listenerName, address, port, connectionsLimit,

--- a/cmd/trickster/listeners.go
+++ b/cmd/trickster/listeners.go
@@ -195,6 +195,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		spinDownListener("metricsListener", 0)
 		mr := http.NewServeMux()
 		mr.Handle("/metrics", metrics.Handler())
+		mr.HandleFunc(conf.Main.ConfigHandlerPath, ph.ConfigHandleFunc(conf))
 		if conf.Main.PprofServer == "both" || conf.Main.PprofServer == "metrics" {
 			routing.RegisterPprofRoutes("metrics", mr, log)
 		}
@@ -211,6 +212,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		wg.Add(1)
 		spinDownListener("reloadListener", time.Millisecond*500)
 		mr := http.NewServeMux()
+		mr.HandleFunc(conf.Main.ConfigHandlerPath, ph.ConfigHandleFunc(conf))
 		mr.Handle(conf.ReloadConfig.HandlerPath, reloadHandler)
 		if conf.Main.PprofServer == "both" || conf.Main.PprofServer == "reload" {
 			routing.RegisterPprofRoutes("reload", mr, log)

--- a/cmd/trickster/listeners_test.go
+++ b/cmd/trickster/listeners_test.go
@@ -38,7 +38,7 @@ func TestListeners(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 300)
 	l := listeners["httpListener"]
-	l.Close()
+	l.listener.Close()
 	time.Sleep(time.Millisecond * 100)
 	if err == nil {
 		t.Error("expected non-nil err")
@@ -51,7 +51,7 @@ func TestListeners(t *testing.T) {
 	}()
 	time.Sleep(time.Millisecond * 300)
 	l = listeners["httpListener2"]
-	l.Close()
+	l.listener.Close()
 	time.Sleep(time.Millisecond * 100)
 	if err == nil {
 		t.Error("expected non-nil err")

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -18,7 +18,6 @@
 package main
 
 import (
-	_ "net/http/pprof" // Comment to disable. Available on :METRICS_PORT/debug/pprof
 	"os"
 	"sync"
 

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -18,25 +18,11 @@
 package main
 
 import (
-	"crypto/tls"
-	"errors"
-	"fmt"
 	_ "net/http/pprof" // Comment to disable. Available on :METRICS_PORT/debug/pprof
 	"os"
 	"sync"
 
-	"github.com/tricksterproxy/trickster/pkg/cache"
-	"github.com/tricksterproxy/trickster/pkg/cache/registration"
-	"github.com/tricksterproxy/trickster/pkg/config"
-	th "github.com/tricksterproxy/trickster/pkg/proxy/handlers"
-	"github.com/tricksterproxy/trickster/pkg/routing"
 	"github.com/tricksterproxy/trickster/pkg/runtime"
-	"github.com/tricksterproxy/trickster/pkg/util/log"
-	tl "github.com/tricksterproxy/trickster/pkg/util/log"
-	"github.com/tricksterproxy/trickster/pkg/util/metrics"
-	tr "github.com/tricksterproxy/trickster/pkg/util/tracing/registration"
-
-	"github.com/gorilla/mux"
 )
 
 var (
@@ -52,174 +38,11 @@ const (
 )
 
 var fatalStartupErrors = true
+var wg = &sync.WaitGroup{}
 
 func main() {
 	runtime.ApplicationName = applicationName
 	runtime.ApplicationVersion = applicationVersion
-	wg := &sync.WaitGroup{}
-	runTrickster(wg, os.Args[1:], fatalStartupErrors)
+	runConfig(nil, wg, nil, os.Args[1:], fatalStartupErrors)
 	wg.Wait()
-}
-
-func runTrickster(wg *sync.WaitGroup, args []string, isStartup bool) {
-
-	var err error
-
-	conf, flags, err := config.Load(runtime.ApplicationName, runtime.ApplicationVersion, args)
-	if err != nil {
-		fmt.Println("\nERROR: Could not load configuration:", err.Error())
-		if flags != nil && !flags.ValidateConfig {
-			PrintUsage()
-		}
-		handleStartupIssue("", nil, nil, isStartup)
-		return
-	}
-
-	if flags.PrintVersion {
-		PrintVersion()
-		return
-	}
-
-	if flags.ValidateConfig {
-		err = validateConfig(conf)
-		if err != nil {
-			handleStartupIssue("ERROR: Could not load configuration: "+err.Error(), nil, nil, true)
-		}
-		fmt.Println("Trickster configuration validation succeeded.")
-		return
-	}
-
-	log := tl.Init(conf)
-	defer log.Close()
-	log.Info("application start up",
-		tl.Pairs{
-			"name":      runtime.ApplicationName,
-			"version":   runtime.ApplicationVersion,
-			"goVersion": applicationGoVersion,
-			"goArch":    applicationGoArch,
-			"commitID":  applicationGitCommitID,
-			"buildTime": applicationBuildTime,
-			"logLevel":  conf.Logging.LogLevel,
-		},
-	)
-
-	for _, w := range conf.LoaderWarnings {
-		log.Warn(w, tl.Pairs{})
-	}
-
-	// Register Tracing Configurations
-	tracerFlushers, err := tr.RegisterAll(conf, log)
-	if err != nil {
-		handleStartupIssue("tracing registration failed", tl.Pairs{"detail": err.Error()}, log, isStartup)
-		return
-	}
-
-	if len(tracerFlushers) > 0 {
-		for _, f := range tracerFlushers {
-			defer f()
-		}
-	}
-
-	router := mux.NewRouter()
-	router.HandleFunc(conf.Main.PingHandlerPath, th.PingHandleFunc(conf)).Methods("GET")
-	router.HandleFunc(conf.Main.ConfigHandlerPath, th.ConfigHandleFunc(conf)).Methods("GET")
-
-	var caches = make(map[string]cache.Cache)
-	for k, v := range conf.Caches {
-		c := registration.NewCache(k, v, log)
-		caches[k] = c
-	}
-
-	_, err = routing.RegisterProxyRoutes(conf, router, caches, log, false)
-	if err != nil {
-		handleStartupIssue("route registration failed", tl.Pairs{"detail": err.Error()}, log, isStartup)
-		return
-	}
-
-	if conf.Frontend.TLSListenPort < 1 && conf.Frontend.ListenPort < 1 {
-		handleStartupIssue("no http or https listeners configured", tl.Pairs{}, log, isStartup)
-		return
-	}
-
-	// if TLS port is configured and at least one origin is mapped to a good tls config,
-	// then set up the tls server listener instance
-	if conf.Frontend.ServeTLS && conf.Frontend.TLSListenPort > 0 {
-		var tlsConfig *tls.Config
-		tlsConfig, err = conf.TLSCertConfig()
-		if err != nil {
-			log.Error("unable to start tls listener due to certificate error", tl.Pairs{"detail": err})
-		} else {
-			wg.Add(1)
-			go startListener("tlsListener",
-				conf.Frontend.TLSListenAddress, conf.Frontend.TLSListenPort,
-				conf.Frontend.ConnectionsLimit, tlsConfig, router, wg, true, log)
-		}
-	}
-
-	// if the plaintext HTTP port is configured, then set up the http listener instance
-	if conf.Frontend.ListenPort > 0 {
-		wg.Add(1)
-		go startListener("httpListener",
-			conf.Frontend.ListenAddress, conf.Frontend.ListenPort,
-			conf.Frontend.ConnectionsLimit, nil, router, wg, true, log)
-	}
-
-	// if the Metrics HTTP port is configured, then set up the http listener instance
-	if conf.Metrics != nil && conf.Metrics.ListenPort > 0 {
-		wg.Add(1)
-		go startListenerRouter("metricsListener",
-			conf.Metrics.ListenAddress, conf.Metrics.ListenPort,
-			conf.Frontend.ConnectionsLimit, nil, "/metrics", metrics.Handler(), wg, true, log)
-	}
-}
-
-func handleStartupIssue(event string, detail log.Pairs, logger *log.TricksterLogger, exitFatal bool) {
-	if event != "" {
-		if logger != nil {
-			if exitFatal {
-				logger.Fatal(1, event, detail)
-				return
-			}
-			logger.Error(event, detail)
-			return
-		}
-		fmt.Println(event)
-	}
-	if exitFatal {
-		os.Exit(1)
-	}
-}
-
-func validateConfig(conf *config.TricksterConfig) error {
-
-	for _, w := range conf.LoaderWarnings {
-		fmt.Println(w)
-	}
-
-	// TODO: Tracers w/ Dry Run
-
-	var caches = make(map[string]cache.Cache)
-	for k := range conf.Caches {
-		caches[k] = nil
-	}
-
-	router := mux.NewRouter()
-	log := log.ConsoleLogger(conf.Logging.LogLevel)
-	_, err := routing.RegisterProxyRoutes(conf, router, caches, log, false)
-	if err != nil {
-		return err
-	}
-
-	if conf.Frontend.TLSListenPort < 1 && conf.Frontend.ListenPort < 1 {
-		return errors.New("no http or https listeners configured")
-	}
-
-	if conf.Frontend.ServeTLS && conf.Frontend.TLSListenPort > 0 {
-		_, err = conf.TLSCertConfig()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -42,6 +42,6 @@ var wg = &sync.WaitGroup{}
 func main() {
 	runtime.ApplicationName = applicationName
 	runtime.ApplicationVersion = applicationVersion
-	runConfig(nil, wg, nil, os.Args[1:], fatalStartupErrors)
+	runConfig(nil, wg, nil, nil, os.Args[1:], fatalStartupErrors)
 	wg.Wait()
 }

--- a/cmd/trickster/main_test.go
+++ b/cmd/trickster/main_test.go
@@ -27,12 +27,12 @@ func TestMain(t *testing.T) {
 	// Successful test criteria is that the call to main returns without timing out on wg.Wait()
 }
 
-func TestRunTrickster(t *testing.T) {
+func TestRunConfig(t *testing.T) {
 	wg := &sync.WaitGroup{}
-	runTrickster(wg, []string{}, false)
+	runConfig(nil, wg, nil, []string{}, false)
 
-	runTrickster(wg, []string{"-version"}, false)
+	runConfig(nil, wg, nil, []string{"-version"}, false)
 
-	runTrickster(wg, []string{"-origin-type", "rpc", "-origin-url", "http://tricksterproxy.io"}, false)
+	runConfig(nil, wg, nil, []string{"-origin-type", "rpc", "-origin-url", "http://tricksterproxy.io"}, false)
 
 }

--- a/cmd/trickster/main_test.go
+++ b/cmd/trickster/main_test.go
@@ -29,10 +29,10 @@ func TestMain(t *testing.T) {
 
 func TestRunConfig(t *testing.T) {
 	wg := &sync.WaitGroup{}
-	runConfig(nil, wg, nil, []string{}, false)
+	runConfig(nil, wg, nil, nil, []string{}, false)
 
-	runConfig(nil, wg, nil, []string{"-version"}, false)
+	runConfig(nil, wg, nil, nil, []string{"-version"}, false)
 
-	runConfig(nil, wg, nil, []string{"-origin-type", "rpc", "-origin-url", "http://tricksterproxy.io"}, false)
+	runConfig(nil, wg, nil, nil, []string{"-origin-type", "rpc", "-origin-url", "http://tricksterproxy.io"}, false)
 
 }

--- a/cmd/trickster/signal.go
+++ b/cmd/trickster/signal.go
@@ -17,7 +17,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -49,7 +48,7 @@ func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *tl.Logger,
 					runConfig(conf, wg, log, caches, args, false)
 					return // runConfig will start a new HupMonitor in place of this one
 				}
-				fmt.Println("configuration NOT reloaded")
+				log.Warn("configuration NOT reloaded", tl.Pairs{})
 			case <-conf.QuitChan:
 				return
 			}

--- a/cmd/trickster/signal.go
+++ b/cmd/trickster/signal.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/tricksterproxy/trickster/pkg/config"
+	"github.com/tricksterproxy/trickster/pkg/util/log"
+)
+
+var hups = make(chan os.Signal, 1)
+
+func init() {
+	signal.Notify(hups, syscall.SIGHUP)
+}
+
+func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *log.Logger, args []string) {
+	// assumes all parameters are instantiated
+	go func() {
+		for {
+			<-hups
+			if conf.IsStale() {
+				runConfig(conf, wg, log, args, false)
+				break // runConfig will start a new HupMonitor in place of this one
+			}
+			fmt.Println("configuration NOT reloaded")
+		}
+	}()
+}

--- a/cmd/trickster/signal.go
+++ b/cmd/trickster/signal.go
@@ -35,7 +35,7 @@ func init() {
 
 func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *tl.Logger,
 	caches map[string]cache.Cache, args []string) {
-	if conf == nil {
+	if conf == nil || conf.Resources == nil {
 		return
 	}
 	// assumes all parameters are instantiated
@@ -49,7 +49,7 @@ func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *tl.Logger,
 					return // runConfig will start a new HupMonitor in place of this one
 				}
 				log.Warn("configuration NOT reloaded", tl.Pairs{})
-			case <-conf.QuitChan:
+			case <-conf.Resources.QuitChan:
 				return
 			}
 		}

--- a/cmd/trickster/signal.go
+++ b/cmd/trickster/signal.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/config"
 	"github.com/tricksterproxy/trickster/pkg/util/log"
 )
@@ -33,7 +34,8 @@ func init() {
 	signal.Notify(hups, syscall.SIGHUP)
 }
 
-func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *log.Logger, args []string) {
+func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *log.Logger,
+	caches map[string]cache.Cache, args []string) {
 	if conf == nil {
 		return
 	}
@@ -43,7 +45,7 @@ func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *log.Logger, a
 			select {
 			case <-hups:
 				if conf.IsStale() {
-					runConfig(conf, wg, log, args, false)
+					runConfig(conf, wg, log, caches, args, false)
 					return // runConfig will start a new HupMonitor in place of this one
 				}
 				fmt.Println("configuration NOT reloaded")

--- a/cmd/trickster/signal.go
+++ b/cmd/trickster/signal.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/config"
-	"github.com/tricksterproxy/trickster/pkg/util/log"
+	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
 var hups = make(chan os.Signal, 1)
@@ -34,7 +34,7 @@ func init() {
 	signal.Notify(hups, syscall.SIGHUP)
 }
 
-func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *log.Logger,
+func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *tl.Logger,
 	caches map[string]cache.Cache, args []string) {
 	if conf == nil {
 		return
@@ -45,6 +45,7 @@ func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *log.Logger,
 			select {
 			case <-hups:
 				if conf.IsStale() {
+					log.Warn("configuration reload starting now", tl.Pairs{"source": "sighup"})
 					runConfig(conf, wg, log, caches, args, false)
 					return // runConfig will start a new HupMonitor in place of this one
 				}

--- a/cmd/trickster/usage.go
+++ b/cmd/trickster/usage.go
@@ -30,6 +30,9 @@ Trickster Usage:
  Print Version Info:
  trickster -version
 
+ Validating a configuration file:
+  trickster -validate-config -config /path/to/file.conf
+
  Using a configuration file:
   trickster -config /path/to/file.conf [-log-level DEBUG|INFO|WARN|ERROR] [-proxy-port 8480] [-metrics-port 8481]
 

--- a/cmd/trickster/usage.go
+++ b/cmd/trickster/usage.go
@@ -66,7 +66,7 @@ https://github.com/tricksterproxy/trickster
 `
 
 func version() string {
-	return fmt.Sprintf("Trickster version: %s, buildInfo: %s %s, goVersion: %s © 2018 Comcast",
+	return fmt.Sprintf("Trickster version: %s, buildInfo: %s %s, goVersion: %s © 2018 Comcast Corporation",
 		runtime.ApplicationVersion,
 		applicationBuildTime, applicationGitCommitID,
 		applicationGoVersion,

--- a/cmd/trickster/usage.go
+++ b/cmd/trickster/usage.go
@@ -66,7 +66,7 @@ https://github.com/tricksterproxy/trickster
 `
 
 func version() string {
-	return fmt.Sprintf("Trickster version: %s, buildInfo: %s %s, goVersion: %s © 2018 Comcast Corporation",
+	return fmt.Sprintf("Trickster version: %s, buildInfo: %s %s, goVersion: %s, copyright: © 2018 Comcast Corporation",
 		runtime.ApplicationVersion,
 		applicationBuildTime, applicationGitCommitID,
 		applicationGoVersion,

--- a/cmd/trickster/usage_test.go
+++ b/cmd/trickster/usage_test.go
@@ -24,14 +24,14 @@ import (
 func ExamplePrintVersion() {
 	runtime.ApplicationVersion = "test"
 	PrintVersion()
-	// Output: Trickster version: test, buildInfo:  , goVersion:  © 2018 Comcast
+	// Output: Trickster version: test, buildInfo:  , goVersion: , copyright: © 2018 Comcast Corporation
 }
 
 func ExamplePrintUsage() {
 
 	runtime.ApplicationVersion = "test"
 	PrintUsage()
-	// Output: Trickster version: test, buildInfo:  , goVersion:  © 2018 Comcast
+	// Output: Trickster version: test, buildInfo:  , goVersion: , copyright: © 2018 Comcast Corporation
 	//
 	// Trickster Usage:
 	//
@@ -39,6 +39,9 @@ func ExamplePrintUsage() {
 	//
 	//  Print Version Info:
 	//  trickster -version
+	//
+	//  Validating a configuration file:
+	//   trickster -validate-config -config /path/to/file.conf
 	//
 	//  Using a configuration file:
 	//   trickster -config /path/to/file.conf [-log-level DEBUG|INFO|WARN|ERROR] [-proxy-port 8480] [-metrics-port 8481]

--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -44,7 +44,7 @@ data:
     [frontend]
 
     # listen_port defines the port on which Trickster's Front-end HTTP Proxy server listens.
-    listen_port = 9090
+    listen_port = 8480
 
     ## listen_address defines the ip on which Trickster's Front-end HTTP Proxy server listens.
     ## empty by default, listening on all interfaces
@@ -244,12 +244,17 @@ data:
     [origins]
 
         # example origin named default. default is always created with these settings unless a different origin is defined here.
-        # access this origin via http[s]://trickster-fqdn/default/
+        # access this origin via http[s]://trickster-fqdn/default/ unless path_routing_disabled is true
         [origins.default]
 
         ## is_default describes whether this origin is the default origin considered when routing http requests
         ## it is false, by default; but if you only have a single origin configured, is_default will be true unless explicitly set to false
         # is_default = true
+
+        ## path_routing_disabled will prevent the origin from being accessible via /origin_name/ path to Trickster. Disabling this requires
+        ## the origin to have hosts configured (see below) or be the target of a rule origin, or it will be unreachable.
+        ## default is false
+        # path_routing_disabled = false
 
         # origin_type identifies the origin type.
         # Valid options are: 'prometheus', 'influxdb', 'clickhouse', 'irondb', 'reverseproxycache' (or just 'rpc')
@@ -419,7 +424,7 @@ data:
 
         ## For multi-origin support, origins are named, and the name is the second word of the configuration section name.
         ## In this example, an origin is named "foo".
-        ## Clients can indicate this origin in their path (http://trickster.example.com:9090/foo/api/v1/query_range?.....)
+        ## Clients can indicate this origin in their path (http://trickster.example.com:8480/foo/api/v1/query_range?.....)
         ## there are other ways for clients to indicate which origin to use in a multi-origin setup. See the documentation for more information
 
         ## use quotes around FQDNs for host-based routing (see /docs/multi-origin.md).
@@ -434,6 +439,33 @@ data:
         # timeout_secs = 180
         # backfill_tolerance_secs = 180
         # tracing_name = 'example'
+
+    ## Configuration Options for Request Routing Rules - see /docs/rule.md for more information
+    #
+    # [rules]
+    ## This example rule will route a request to the reader or writer origin based on the Username header
+    #
+    #   [rules.example]
+    #   input_source = 'header'       # path, host, param
+    #   input_key = 'Authorization'   # Authorization: Basic SomeBase64EncodedString
+    #   input_type = 'string'
+    #   input_encoding = 'base64'
+    #   input_index = 1               # split the header value into zero-indexed parts at spaces, use part 1
+    #   input_delimiter = ' '
+    #   operation = 'prefix'              # check the input value matches any of the defined cases:
+    #   next_route = 'reader-cluster' # by default, route to reader-cluster origin (would need to be defined)
+    # 	[rules.example.cases]
+    # 		[rules.example.cases.1]
+    # 		matches = ['johndoe:', 'janedoe:']  # if the Authorization header has user johndoe or janedoe,
+    # 		next_route = 'writer-cluster'       # route the request to hypothetical writer-cluster origin
+
+    ## Configuration Options for Request Rewriter Instructions - see /docs/request_rewriters.md for more info
+    #
+    # [request_rewriters]
+    #   [request_rewriters.example-set-upstream-user]
+    #   instructions = [
+    #     ['header', 'set', 'Authorization', 'Basic SomeBase64EncodedCredentials'],
+    #   ]
 
     ## Configuration Options for Tracing Instrumentation. see /docs/tracing.md for more information
     # [tracing]
@@ -457,8 +489,8 @@ data:
 
         ## An integer or floating point value of 0 to 1.0 (inclusive) is permitted.
         ## sampleRate sets the probability that a span will be recorded.
-        ## default is 1 (meaning 100% of requests are recorded)
-        # sample_rate = 1
+        ## default is 1.0 (meaning 100% of requests are recorded)
+        # sample_rate = 1.0
         
         ## another example tracing config named 'example' using jaeger backend and a 50% sample rate
         # [tracing.example]
@@ -470,10 +502,31 @@ data:
     ## Configuration Options for Metrics Instrumentation
     # [metrics]
     ## listen_port defines the port that Trickster's metrics server listens on at /metrics
-    # listen_port = 8082
+    ## 8481 is the default
+    # listen_port = 8481
     ## listen_address defines the ip that Trickster's metrics server listens on at /metrics
     ## empty by default, listening on all interfaces
     # listen_address = ''
+
+    ## Configuration Options for Config Reloading
+    # [reloading]
+    ## listen_port defines the port where Trickster's config reload server listens
+    ## 8484 is the default 
+    # listen_port = 8484
+    ## listen_address defines the ip where Trickster's config reload server listens
+    ## empty by default, listening on all interfaces
+    # listen_address = ''
+    ## handler_path defines the HTTP path where the Reload interface is available.
+    ## by default, this is '/trickster/config/reload'
+    # handler_path = '/trickster/config/reload'
+    ## bleed_timeout_secs defines how long old HTTP listeners will live to allow
+    ## outstanding connection to close organically, before the listener is forcefully closed
+    ## the default is 30
+    # bleed_timeout_secs = 30
+    ## rate_limit_secs specifies the rate limit timeout duration to apply to the HTTP reload interface.
+    ## The reload interface is disabled for this duration of time whenever a config reload request is
+    ## made that fails because the underlying config file is unmodified. default is 3
+    # rate_limit_secs = 3
 
     ## Configuration Options for Logging Instrumentation
     # [logging]

--- a/deploy/kube/service.yaml
+++ b/deploy/kube/service.yaml
@@ -3,13 +3,13 @@ kind: Service
 metadata:
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "8082"
+    prometheus.io/port: "8481"
     prometheus.io/path: "/metrics"
   name: trickster
 spec:
   ports:
-    - port: 9090
-      targetPort: 9090
+    - port: 8480
+      targetPort: 8480
       name: metrics
   selector:
     name: trickster

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -40,3 +40,31 @@ Finally, Trickster will check for and evaluate the following Command Line Argume
 * `-origin-type prometheus` - The type of [supported origin server](./supported-origin-types.md)
 * `-proxy-port 8480` - Listener port for the HTTP Proxy Endpoint
 * `-metrics-port 8481` - Listener port for the Metrics and pprof debugging HTTP Endpoint
+
+## Configuration Validation
+
+Trickster can validate a configuration file by running `trickster -validate-config -config /path/to/config`. Trickster will load the configuration and exit with the validation result, without running the configuration.
+
+## Reloading the Configuration
+
+Trickster can gracefully reload the configuration file from disk without impacting the uptime and responsiveness of the the application.
+
+Trickster provides 2 ways to reload the Trickster configuration: by requesting an HTTP endpoint, or by sending a SIGHUP (e.g., `kill -1 $TRICKSTER_PID`) to the Trickster process. In both cases, the underlying running Configuration File must have been modified such that the last modified time of the file is different than from when it was previously loaded.
+
+### Config Reload via SIGHUP
+
+Once you have made the desired modifications to your config file, send a SIGHUP to the Trickster process by running `kill -1 $TRICKSTER_PID`. The Trickster log will indicate whether the reload attempt was successful or not.
+
+### Config Reload via HTTP Endpoint
+
+Trickster provides an HTTP Endpoint for viewing the running Configuration, as well as requesting a configuration reload.
+
+The reload endpoint is configured by default to listen on address `127.0.0.1` and port `8484`, at `/trickster/config/reload`. These values can be customized, as demonstrated in the example.conf. The examples in this section will assume the defaults. Set the port to `-1` to disable the reload HTTP interface altogether.
+
+To reload the config, simply make a `GET` request to the reload endpoint. If the underlying configuration file has changed, the configuration will be reloaded, and the caller will receive a success response. If the underlying file has not chnaged, the caller will receive an unsuccessful response, and reloading will be disabled for the duration of the Reload Rate Limiter. By default, this is 3 seconds, but can be customized as demonstrated in the example config file. The Reload Rate Limiter applies to the HTTP interface only, and not SIGHUP.
+
+If an HTTP listener must spin down (e.g., the listen port is changed in the refreshed config), the old listener will remain alive for a period of time to allow existing connections to organically finish. This period is called the Drain Timeout and is configurable. Trickster uses 30 seconds by default. The Drain Timeout also applies to old log files, in the event that a new log filename has been provided.
+
+### View the Running Configuration
+
+Trickster also provides a `http://127.0.0.1:8484/trickster/config` endpoint, which returns the toml output of the currently-running Trickster configuration. The TOML-formatted configuration will include all defaults populated, overlaid with any configuration file settings, command-line arguments and or applicable environment variables. This read-only interface is also available via the metrics endpoint, in the event that the reload endpoint has been disabled. This path is configurable as demonstrated in the example config file.

--- a/docs/health.md
+++ b/docs/health.md
@@ -19,7 +19,3 @@ The HTTP Reverse Proxy Cache origin type does not have a built-in health check, 
 ## Other Ways to Monitor Health
 
 In addition to the out-of-the-box health checks to determine up-or-down status, you may want to setup alarms and thresholds based on the metrics instrumented by Trickster. See [metrics.md](metrics.md) for collecting performance metrics about Trickster.
-
-## Config Endpoint
-
-Trickster also provides a `/trickster/config` endpoint, that returns the toml output of the currently-running Trickster configuration. The TOML-formatted configuration will include all defaults populated, overlaid with any configuration file settings, command-line arguments and or applicable environment variables. The path to the Config endpoint is configurable, see the configuration documentation for more information.

--- a/pkg/cache/badger/badger.go
+++ b/pkg/cache/badger/badger.go
@@ -20,6 +20,7 @@ package badger
 import (
 	"time"
 
+	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/cache/metrics"
 	"github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
@@ -87,6 +88,7 @@ func (c *Cache) Retrieve(cacheKey string, allowExpired bool) ([]byte, status.Loo
 	}
 
 	if err == badger.ErrKeyNotFound {
+		err = cache.ErrKNF
 		c.Logger.Debug("badger cache miss", log.Pairs{"key": cacheKey})
 		metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.CacheType)
 		return nil, status.LookupStatusKeyMiss, err

--- a/pkg/cache/badger/badger.go
+++ b/pkg/cache/badger/badger.go
@@ -107,7 +107,7 @@ func (c *Cache) Remove(cacheKey string) {
 }
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Badger
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	c.Logger.Debug("badger cache bulk remove", log.Pairs{})
 
 	c.dbh.Update(func(txn *badger.Txn) error {

--- a/pkg/cache/badger/badger.go
+++ b/pkg/cache/badger/badger.go
@@ -32,7 +32,7 @@ import (
 type Cache struct {
 	Name   string
 	Config *options.Options
-	Logger *log.TricksterLogger
+	Logger *log.Logger
 	dbh    *badger.DB
 }
 

--- a/pkg/cache/badger/badger_test.go
+++ b/pkg/cache/badger/badger_test.go
@@ -161,8 +161,8 @@ func TestBadgerCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	bc.BulkRemove([]string{""}, true)
-	bc.BulkRemove([]string{cacheKey}, true)
+	bc.BulkRemove([]string{""})
+	bc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = bc.Retrieve(cacheKey, false)

--- a/pkg/cache/badger/options/options_test.go
+++ b/pkg/cache/badger/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/cache/badger/options/options_test.go
+++ b/pkg/cache/badger/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/cache/bbolt/bbolt.go
+++ b/pkg/cache/bbolt/bbolt.go
@@ -38,7 +38,7 @@ type Cache struct {
 	Name   string
 	Config *options.Options
 	dbh    *bbolt.DB
-	Logger *log.TricksterLogger
+	Logger *log.Logger
 	Index  *index.Index
 }
 

--- a/pkg/cache/bbolt/bbolt.go
+++ b/pkg/cache/bbolt/bbolt.go
@@ -164,7 +164,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) ([]byte
 	if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
 		c.Logger.Debug("bbolt cache retrieve", log.Pairs{"cacheKey": cacheKey})
 		if atime {
-			c.Index.UpdateObjectAccessTime(cacheKey)
+			go c.Index.UpdateObjectAccessTime(cacheKey)
 		}
 		metrics.ObserveCacheOperation(c.Name, c.Config.CacheType, "get", "hit", float64(len(data)))
 		locks.Release(lockPrefix + cacheKey)
@@ -192,7 +192,7 @@ func (c *Cache) Remove(cacheKey string) {
 	locks.Release(lockPrefix + cacheKey)
 }
 
-func (c *Cache) remove(cacheKey string, noLock bool) error {
+func (c *Cache) remove(cacheKey string, isBulk bool) error {
 
 	err := c.dbh.Update(func(tx *bbolt.Tx) error {
 		b := tx.Bucket([]byte(c.Config.BBolt.Bucket))
@@ -202,16 +202,18 @@ func (c *Cache) remove(cacheKey string, noLock bool) error {
 		c.Logger.Error("bbolt cache key delete failure", log.Pairs{"cacheKey": cacheKey, "reason": err.Error()})
 		return err
 	}
-	c.Index.RemoveObject(cacheKey, noLock)
+	if !isBulk {
+		c.Index.RemoveObject(cacheKey)
+	}
 	metrics.ObserveCacheDel(c.Name, c.Config.CacheType, 0)
 	c.Logger.Debug("bbolt cache key delete", log.Pairs{"key": cacheKey})
 	return nil
 }
 
 // BulkRemove removes a list of objects from the cache
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	for _, cacheKey := range cacheKeys {
-		c.remove(cacheKey, noLock)
+		c.remove(cacheKey, true)
 	}
 }
 

--- a/pkg/cache/bbolt/bbolt_test.go
+++ b/pkg/cache/bbolt/bbolt_test.go
@@ -412,7 +412,7 @@ func TestBboltCache_BulkRemove(t *testing.T) {
 	if ls != status.LookupStatusHit {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
-	bc.BulkRemove([]string{cacheKey}, true)
+	bc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = bc.Retrieve(cacheKey, false)
@@ -434,7 +434,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
 	}
 
-	bc.BulkRemove(keyArray, true)
+	bc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/pkg/cache/bbolt/options/options_test.go
+++ b/pkg/cache/bbolt/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/cache/bbolt/options/options_test.go
+++ b/pkg/cache/bbolt/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -37,7 +37,7 @@ type Cache interface {
 	Retrieve(cacheKey string, allowExpired bool) ([]byte, status.LookupStatus, error)
 	SetTTL(cacheKey string, ttl time.Duration)
 	Remove(cacheKey string)
-	BulkRemove(cacheKeys []string, noLock bool)
+	BulkRemove(cacheKeys []string)
 	Close() error
 	Configuration() *options.Options
 }
@@ -50,7 +50,7 @@ type MemoryCache interface {
 	Retrieve(cacheKey string, allowExpired bool) ([]byte, status.LookupStatus, error)
 	SetTTL(cacheKey string, ttl time.Duration)
 	Remove(cacheKey string)
-	BulkRemove(cacheKeys []string, noLock bool)
+	BulkRemove(cacheKeys []string)
 	Close() error
 	Configuration() *options.Options
 	StoreReference(cacheKey string, data ReferenceObject, ttl time.Duration) error

--- a/pkg/cache/filesystem/filesystem.go
+++ b/pkg/cache/filesystem/filesystem.go
@@ -145,7 +145,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) ([]byte
 	if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
 		c.Logger.Debug("filesystem cache retrieve", log.Pairs{"key": cacheKey, "dataFile": dataFile})
 		if atime {
-			c.Index.UpdateObjectAccessTime(cacheKey)
+			go c.Index.UpdateObjectAccessTime(cacheKey)
 		}
 		metrics.ObserveCacheOperation(c.Name, c.Config.CacheType, "get", "hit", float64(len(data)))
 		locks.Release(lockPrefix + cacheKey)
@@ -170,18 +170,18 @@ func (c *Cache) Remove(cacheKey string) {
 	locks.Release(lockPrefix + cacheKey)
 }
 
-func (c *Cache) remove(cacheKey string, noLock bool) {
+func (c *Cache) remove(cacheKey string, isBulk bool) {
 
-	if err := os.Remove(c.getFileName(cacheKey)); err == nil {
-		c.Index.RemoveObject(cacheKey, noLock)
+	if err := os.Remove(c.getFileName(cacheKey)); err == nil && !isBulk {
+		c.Index.RemoveObject(cacheKey)
 	}
 	metrics.ObserveCacheDel(c.Name, c.Config.CacheType, 0)
 }
 
 // BulkRemove removes a list of objects from the cache
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	for _, cacheKey := range cacheKeys {
-		c.remove(cacheKey, noLock)
+		c.remove(cacheKey, true)
 	}
 }
 

--- a/pkg/cache/filesystem/filesystem.go
+++ b/pkg/cache/filesystem/filesystem.go
@@ -40,7 +40,7 @@ type Cache struct {
 	Name   string
 	Config *options.Options
 	Index  *index.Index
-	Logger *log.TricksterLogger
+	Logger *log.Logger
 }
 
 // Configuration returns the Configuration for the Cache object

--- a/pkg/cache/filesystem/filesystem_test.go
+++ b/pkg/cache/filesystem/filesystem_test.go
@@ -568,7 +568,7 @@ func TestFilesystemCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	fc.BulkRemove([]string{cacheKey}, true)
+	fc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = fc.Retrieve(cacheKey, false)
@@ -589,7 +589,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
 	}
 
-	fc.BulkRemove(keyArray, true)
+	fc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/pkg/cache/filesystem/options/options_test.go
+++ b/pkg/cache/filesystem/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/cache/filesystem/options/options_test.go
+++ b/pkg/cache/filesystem/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/cache/index/index.go
+++ b/pkg/cache/index/index.go
@@ -98,7 +98,7 @@ func ObjectFromBytes(data []byte) (*Object, error) {
 // NewIndex returns a new Index based on the provided inputs
 func NewIndex(cacheName, cacheType string, indexData []byte, cfg *options.Options,
 	bulkRemoveFunc func([]string, bool), flushFunc func(cacheKey string, data []byte),
-	log *tl.TricksterLogger) *Index {
+	log *tl.Logger) *Index {
 	i := &Index{}
 
 	if len(indexData) > 0 {
@@ -222,7 +222,7 @@ func (idx *Index) GetExpiration(cacheKey string) time.Time {
 }
 
 // flusher periodically calls the cache's index flush func that writes the cache index to disk
-func (idx *Index) flusher(log *tl.TricksterLogger) {
+func (idx *Index) flusher(log *tl.Logger) {
 	var lastFlush time.Time
 	for {
 		time.Sleep(idx.flushInterval)
@@ -234,7 +234,7 @@ func (idx *Index) flusher(log *tl.TricksterLogger) {
 	}
 }
 
-func (idx *Index) flushOnce(log *tl.TricksterLogger) {
+func (idx *Index) flushOnce(log *tl.Logger) {
 	indexLock.Lock()
 	bytes, err := idx.MarshalMsg(nil)
 	indexLock.Unlock()
@@ -246,7 +246,7 @@ func (idx *Index) flushOnce(log *tl.TricksterLogger) {
 }
 
 // reaper continually iterates through the cache to find expired elements and removes them
-func (idx *Index) reaper(log *tl.TricksterLogger) {
+func (idx *Index) reaper(log *tl.Logger) {
 	for {
 		idx.reap(log)
 		time.Sleep(idx.reapInterval)
@@ -257,7 +257,7 @@ type objectsAtime []*Object
 
 // reap makes a single iteration through the cache index to to find and remove expired elements
 // and evict least-recently-accessed elements to maintain the Maximum allowed Cache Size
-func (idx *Index) reap(log *tl.TricksterLogger) {
+func (idx *Index) reap(log *tl.Logger) {
 
 	indexLock.Lock()
 	defer indexLock.Unlock()

--- a/pkg/cache/index/index.go
+++ b/pkg/cache/index/index.go
@@ -18,7 +18,6 @@
 package index
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -135,7 +134,6 @@ func NewIndex(cacheName, cacheType string, indexData []byte, o *options.Options,
 // UpdateOptions updates the existing Index with a new Options reference
 func (idx *Index) UpdateOptions(o *options.Options) {
 	indexLock.Lock()
-	fmt.Println("Updating Index Options!", o)
 	idx.options = o
 	indexLock.Unlock()
 }

--- a/pkg/cache/index/index_test.go
+++ b/pkg/cache/index/index_test.go
@@ -30,10 +30,7 @@ var testLogger = tl.ConsoleLogger("error")
 
 var testBulkIndex *Index
 
-func testBulkRemoveFunc(cacheKeys []string, noLock bool) {
-	for _, cacheKey := range cacheKeys {
-		testBulkIndex.RemoveObject(cacheKey, noLock)
-	}
+func testBulkRemoveFunc(cacheKeys []string) {
 }
 func fakeFlusherFunc(string, []byte) {}
 
@@ -221,7 +218,7 @@ func TestRemoveObject(t *testing.T) {
 		t.Errorf("test object missing from index")
 	}
 
-	idx.RemoveObject("test", false)
+	idx.RemoveObject("test")
 	if _, ok := idx.Objects["test"]; ok {
 		t.Errorf("test object should be missing from index")
 	}

--- a/pkg/cache/index/index_test.go
+++ b/pkg/cache/index/index_test.go
@@ -283,3 +283,28 @@ func TestUpdateObjectTTL(t *testing.T) {
 	}
 
 }
+
+func TestUpdateOptions(t *testing.T) {
+
+	cacheConfig := &co.Options{CacheType: "test", Index: &io.Options{ReapInterval: time.Second * time.Duration(10), FlushInterval: time.Second * time.Duration(10)}}
+	idx := NewIndex("test", "test", nil, cacheConfig.Index, testBulkRemoveFunc, fakeFlusherFunc, testLogger)
+
+	options := io.NewOptions()
+	options.MaxSizeBytes = 5
+	idx.UpdateOptions(options)
+
+	if idx.options.MaxSizeBytes != 5 {
+		t.Errorf("expected %d got %d", 5, idx.options.MaxSizeBytes)
+	}
+}
+
+func TestRemoveObjects(t *testing.T) {
+	cacheConfig := &co.Options{CacheType: "test", Index: &io.Options{ReapInterval: time.Second * time.Duration(10), FlushInterval: time.Second * time.Duration(10)}}
+	idx := NewIndex("test", "test", nil, cacheConfig.Index, testBulkRemoveFunc, fakeFlusherFunc, testLogger)
+	obj := &Object{Key: "test", Value: []byte("test_value")}
+	idx.UpdateObject(obj)
+	idx.RemoveObjects([]string{"test"}, false)
+	if _, ok := idx.Objects["test"]; ok {
+		t.Error("key should not be in map")
+	}
+}

--- a/pkg/cache/index/options/options.go
+++ b/pkg/cache/index/options/options.go
@@ -56,3 +56,19 @@ func NewOptions() *Options {
 		MaxSizeBackoffObjects: d.DefaultMaxSizeBackoffObjects,
 	}
 }
+
+// Equal returns true if all members of the subject and provided Options
+// are identical
+func (o *Options) Equal(o2 *Options) bool {
+
+	if o2 == nil {
+		return false
+	}
+
+	return o.ReapIntervalSecs == o2.ReapIntervalSecs &&
+		o.FlushIntervalSecs == o2.FlushIntervalSecs &&
+		o.MaxSizeBytes == o2.MaxSizeBytes &&
+		o.MaxSizeBackoffBytes == o2.MaxSizeBackoffBytes &&
+		o.MaxSizeObjects == o2.MaxSizeObjects &&
+		o.MaxSizeBackoffObjects == o2.MaxSizeBackoffObjects
+}

--- a/pkg/cache/index/options/options_test.go
+++ b/pkg/cache/index/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/cache/index/options/options_test.go
+++ b/pkg/cache/index/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/cache/index/options/options_test.go
+++ b/pkg/cache/index/options/options_test.go
@@ -24,3 +24,17 @@ func TestNewOptions(t *testing.T) {
 		t.Error("expected non-nil options")
 	}
 }
+
+func TestEqual(t *testing.T) {
+
+	o := NewOptions()
+
+	if o.Equal(nil) {
+		t.Error("expected false")
+	}
+
+	if !o.Equal(o) {
+		t.Error("expected true")
+	}
+
+}

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -39,7 +39,7 @@ type Cache struct {
 	client sync.Map
 	Config *options.Options
 	Index  *index.Index
-	Logger *tl.TricksterLogger
+	Logger *tl.Logger
 }
 
 // Configuration returns the Configuration for the Cache object

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -134,7 +134,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) (*index
 		if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
 			c.Logger.Debug("memory cache retrieve", tl.Pairs{"cacheKey": cacheKey})
 			if atime {
-				c.Index.UpdateObjectAccessTime(cacheKey)
+				go c.Index.UpdateObjectAccessTime(cacheKey)
 			}
 			metrics.ObserveCacheOperation(c.Name, c.Config.CacheType, "get", "hit", float64(len(o.Value)))
 			locks.Release(lockPrefix + cacheKey)
@@ -159,19 +159,27 @@ func (c *Cache) Remove(cacheKey string) {
 	c.remove(cacheKey, false)
 }
 
-func (c *Cache) remove(cacheKey string, noLock bool) {
+func (c *Cache) remove(cacheKey string, isBulk bool) {
 	locks.Acquire(lockPrefix + cacheKey)
 	c.client.Delete(cacheKey)
-	c.Index.RemoveObject(cacheKey, noLock)
+	if !isBulk {
+		c.Index.RemoveObject(cacheKey)
+	}
 	metrics.ObserveCacheDel(c.Name, c.Config.CacheType, 0)
 	locks.Release(lockPrefix + cacheKey)
 }
 
 // BulkRemove removes a list of objects from the cache
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
+	wg := &sync.WaitGroup{}
 	for _, cacheKey := range cacheKeys {
-		c.remove(cacheKey, noLock)
+		wg.Add(1)
+		go func(key string) {
+			c.remove(key, true)
+			wg.Done()
+		}(cacheKey)
 	}
+	wg.Wait()
 }
 
 // Close is not used for Cache, and is here to fully prototype the Cache Interface

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -345,7 +345,7 @@ func TestCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	mc.BulkRemove([]string{cacheKey}, true)
+	mc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = mc.Retrieve(cacheKey, false)
@@ -366,7 +366,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 
 	mc := storeBenchmark(b)
 
-	mc.BulkRemove(keyArray, true)
+	mc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/pkg/cache/options/options.go
+++ b/pkg/cache/options/options.go
@@ -112,3 +112,17 @@ func (cc *Options) Clone() *Options {
 	return c
 
 }
+
+// Equal returns true if all values in the Options references and their
+// their child Option references are completely identical
+func (cc *Options) Equal(cc2 *Options) bool {
+
+	if cc2 == nil {
+		return false
+	}
+
+	return cc.Name == cc2.Name &&
+		cc.CacheType == cc2.CacheType &&
+		cc.CacheTypeID == cc2.CacheTypeID
+
+}

--- a/pkg/cache/options/options_test.go
+++ b/pkg/cache/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/cache/options/options_test.go
+++ b/pkg/cache/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/cache/redis/options/options_test.go
+++ b/pkg/cache/redis/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/cache/redis/options/options_test.go
+++ b/pkg/cache/redis/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -124,7 +124,7 @@ func (c *Cache) SetTTL(cacheKey string, ttl time.Duration) {
 }
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Redis
-func (c *Cache) BulkRemove(cacheKeys []string, noLock bool) {
+func (c *Cache) BulkRemove(cacheKeys []string) {
 	c.Logger.Debug("redis cache bulk remove", tl.Pairs{})
 	c.client.Del(cacheKeys...)
 	metrics.ObserveCacheDel(c.Name, c.Config.CacheType, float64(len(cacheKeys)))

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -37,7 +37,7 @@ const Redis = "redis"
 type Cache struct {
 	Name   string
 	Config *options.Options
-	Logger *tl.TricksterLogger
+	Logger *tl.Logger
 
 	client redis.Cmdable
 	closer func() error

--- a/pkg/cache/redis/redis_test.go
+++ b/pkg/cache/redis/redis_test.go
@@ -481,7 +481,7 @@ func TestCache_BulkRemove(t *testing.T) {
 		t.Errorf("expected %s got %s", status.LookupStatusHit, ls)
 	}
 
-	rc.BulkRemove([]string{cacheKey}, true)
+	rc.BulkRemove([]string{cacheKey})
 
 	// it should be a cache miss
 	_, ls, err = rc.Retrieve(cacheKey, false)
@@ -502,7 +502,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		keyArray = append(keyArray, cacheKey+strconv.Itoa(n))
 	}
 
-	rc.BulkRemove(keyArray, true)
+	rc.BulkRemove(keyArray)
 
 	// it should be a cache miss
 	for n := 0; n < b.N; n++ {

--- a/pkg/cache/registration/registration.go
+++ b/pkg/cache/registration/registration.go
@@ -50,7 +50,7 @@ const (
 // }
 
 // LoadCachesFromConfig iterates the Caching Config and Connects/Maps each Cache
-func LoadCachesFromConfig(conf *config.TricksterConfig, logger *tl.TricksterLogger) map[string]cache.Cache {
+func LoadCachesFromConfig(conf *config.Config, logger *tl.Logger) map[string]cache.Cache {
 	caches := make(map[string]cache.Cache)
 	for k, v := range conf.Caches {
 		c := NewCache(k, v, logger)
@@ -70,7 +70,7 @@ func CloseCaches(caches map[string]cache.Cache) error {
 }
 
 // NewCache returns a Cache object based on the provided config.CachingConfig
-func NewCache(cacheName string, cfg *options.Options, logger *tl.TricksterLogger) cache.Cache {
+func NewCache(cacheName string, cfg *options.Options, logger *tl.Logger) cache.Cache {
 
 	var c cache.Cache
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,6 +83,8 @@ type MainConfig struct {
 	PingHandlerPath string `toml:"ping_handler_path"`
 	// ReloadHandlerPath provides the path to register the Config Reload Handler
 	ReloadHandlerPath string `toml:"reload_handler_path"`
+	// ConfigFilePath provides the path to the config file used in this running config
+	ConfigFilePath string `toml:"-"`
 }
 
 // FrontendConfig is a collection of configurations for the main http frontend for the application

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -736,13 +736,13 @@ func (c *Config) Clone() *Config {
 // IsStale returns true if the running config is stale versus the
 func (c *Config) IsStale() bool {
 
+	c.Main.stalenessCheckLock.Lock()
+	defer c.Main.stalenessCheckLock.Unlock()
+
 	if c.Main == nil || c.Main.configFilePath == "" ||
 		time.Now().Before(c.Main.configRateLimitTime) {
 		return false
 	}
-
-	c.Main.stalenessCheckLock.Lock()
-	defer c.Main.stalenessCheckLock.Unlock()
 
 	if c.ReloadConfig == nil {
 		c.ReloadConfig = reload.NewOptions()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,7 +18,6 @@ package config
 
 import (
 	"errors"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -35,17 +34,20 @@ func TestClone(t *testing.T) {
 	oc := c1.Origins["default"]
 	c1.NegativeCacheConfigs["default"]["404"] = 10
 
+	const expected = "trickster"
+
 	oc.CompressableTypeList = []string{"text/plain"}
 	oc.CompressableTypes = map[string]bool{"text/plain": true}
 	oc.NegativeCacheName = "default"
 	oc.NegativeCache = map[int]time.Duration{404: time.Duration(10) * time.Second}
 	oc.FastForwardPath = po.NewOptions()
 	oc.TLS = &to.Options{CertificateAuthorityPaths: []string{"foo"}}
-	oc.HealthCheckHeaders = map[string]string{headers.NameAuthorization: "Basic SomeHash"}
+	oc.HealthCheckHeaders = map[string]string{headers.NameAuthorization: expected}
 
 	c2 := c1.Clone()
-	if !reflect.DeepEqual(c1, c2) {
-		t.Errorf("copy mistmatch")
+	x := c2.Origins["default"].HealthCheckHeaders[headers.NameAuthorization]
+	if x != expected {
+		t.Errorf("clone mismatch")
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -18,15 +18,29 @@ package config
 
 import (
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
+	d "github.com/tricksterproxy/trickster/pkg/config/defaults"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
 	po "github.com/tricksterproxy/trickster/pkg/proxy/paths/options"
+	rwo "github.com/tricksterproxy/trickster/pkg/proxy/request/rewriter/options"
 	to "github.com/tricksterproxy/trickster/pkg/proxy/tls/options"
 )
+
+const emptyFilePath = "../../testdata/test.empty.conf"
+
+func emptyTestConfig() (*Config, string) {
+	const path = emptyFilePath
+	c, _, _ := Load("testing", "testing", []string{"-config", path})
+	s, _ := ioutil.ReadFile(path)
+	return c, string(s)
+}
 
 func TestClone(t *testing.T) {
 	c1 := NewConfig()
@@ -95,6 +109,270 @@ func TestCloneOriginConfig(t *testing.T) {
 
 	if oc2.Hosts[0] != "test" {
 		t.Errorf("expected %s got %s", "test", oc2.Hosts[0])
+	}
+
+}
+
+func TestCheckFileLastModified(t *testing.T) {
+
+	c := NewConfig()
+
+	if !c.CheckFileLastModified().IsZero() {
+		t.Error("expected zero time")
+	}
+
+	c.Main.configFilePath = "\t\n"
+	if !c.CheckFileLastModified().IsZero() {
+		t.Error("expected zero time")
+	}
+}
+
+func TestProcessPprofConfig(t *testing.T) {
+
+	c := NewConfig()
+	c.Main.PprofServer = ""
+
+	err := c.processPprofConfig()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if c.Main.PprofServer != d.DefaultPprofServerName {
+		t.Errorf("expected %s got %s", d.DefaultPprofServerName, c.Main.PprofServer)
+	}
+
+	c.Main.PprofServer = "x"
+
+	err = c.processPprofConfig()
+	if err == nil {
+		t.Error("expected error for invalid pprof server name")
+	}
+
+}
+
+func TestSetDefaults(t *testing.T) {
+
+	c, _ := emptyTestConfig()
+
+	c.Main.PprofServer = "x"
+	err := c.setDefaults(nil)
+	if err == nil {
+		t.Error("expected error for invalid pprof server name")
+	}
+
+	c.Main.PprofServer = "both"
+	c.RequestRewriters = make(map[string]*rwo.Options)
+	err = c.setDefaults(nil)
+	if err == nil {
+		t.Error("expected error for invalid pprof server name")
+	}
+}
+
+func TestValidateConfigMappings(t *testing.T) {
+
+	c, toml := emptyTestConfig()
+	oc := c.Origins["test"]
+
+	c.Origins["frontend"] = oc
+	err := c.validateConfigMappings()
+	if err == nil {
+		t.Error("expected error for invalid origin name")
+	}
+
+	delete(c.Origins, "frontend")
+	oc.OriginType = "rule"
+	oc.RuleName = "invalid"
+	err = c.validateConfigMappings()
+	if err == nil {
+		t.Error("expected error for invalid rule name")
+	}
+
+	toml = strings.Replace(
+		toml+testRule,
+		"    origin_type = 'test'",
+		"    origin_type = 'rule'\n    rule_name = 'example'",
+		-1,
+	)
+
+	c.loadTOMLConfig(toml, &Flags{})
+	err = c.validateConfigMappings()
+	if err != nil {
+		t.Error(err)
+	}
+
+}
+
+const testRule = `
+[rules]
+  [rules.example]
+  input_source = 'path'
+  input_type = 'string'
+  operation = 'prefix'
+  next_route = 'test'
+	[rules.example.cases]
+		[rules.example.cases.1]
+		matches = ['trickster']
+		next_route = 'test'
+`
+
+const testRewriter = `
+[request_rewriters]
+  [request_rewriters.example]
+    instructions = [
+      ['path', 'set', '/api/v1/query'],
+      ['param', 'delete', 'start'],
+      ['param', 'delete', 'end'],
+      ['param', 'delete', 'step']
+	]
+`
+
+const testPaths = `
+	[origins.test.paths]
+	  [origins.test.paths.root]
+	  path = '/'
+	  match_type = 'prefix'
+	  handler = 'proxycache'
+	  req_rewriter_name = 'example'
+`
+
+func TestProcessOriginConfigs(t *testing.T) {
+
+	c, _ := emptyTestConfig()
+	c.Origins["test"].ReqRewriterName = "invalid"
+	toml := c.String() + testRewriter
+	err := c.loadTOMLConfig(toml, &Flags{})
+	if err == nil {
+		t.Error("expected error for invalid rewriter name")
+	}
+
+	toml = strings.Replace(strings.Replace(
+		toml,
+		`req_rewriter_name = "invalid"`,
+		`req_rewriter_name = "example"`,
+		-1), "['path',", "['patha',", -1,
+	)
+
+	err = c.loadTOMLConfig(toml, &Flags{})
+	if err == nil {
+		t.Error("expected error for rewriter compilation")
+	}
+
+	toml = strings.Replace(toml, "['patha',", "['path',", -1)
+	err = c.loadTOMLConfig(toml, &Flags{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	toml = strings.Replace(
+		c.String(),
+		"[origins.test.paths]",
+		testPaths,
+		-1,
+	)
+
+	err = c.loadTOMLConfig(toml, &Flags{})
+	if err != nil {
+		t.Error(err)
+	}
+
+	toml = strings.Replace(
+		toml,
+		`	  req_rewriter_name = 'example'`,
+		`	  req_rewriter_name = 'invalid'`,
+		-1,
+	)
+
+	err = c.loadTOMLConfig(toml, &Flags{})
+	if err == nil || !strings.Contains(err.Error(), "invalid rewriter name") {
+		t.Error("expected toml parsing error")
+	}
+
+}
+
+func TestLoadTOMLConfig(t *testing.T) {
+
+	c := NewConfig()
+	err := c.loadTOMLConfig("[[", nil)
+	if err == nil || !strings.Contains(err.Error(), "unexpected end of table name") {
+		t.Error("expected toml parsing error")
+	}
+
+	c, tml := emptyTestConfig()
+	err = c.loadTOMLConfig(tml, &Flags{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestIsStale(t *testing.T) {
+
+	testFile := fmt.Sprintf("/tmp/trickster_test_config.%d.conf", time.Now().UnixNano())
+	c, tml := emptyTestConfig()
+
+	err := ioutil.WriteFile(testFile, []byte(tml), 0666)
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(testFile)
+
+	c, _, _ = Load("testing", "testing", []string{"-config", testFile})
+	c.ReloadConfig.RateLimitSecs = 0
+
+	if c.IsStale() {
+		t.Error("expected non-stale config")
+	}
+
+	temp := c.Main.configFilePath
+	c.Main.configFilePath = testFile + ".invalid"
+	if c.IsStale() {
+		t.Error("expected non-stale config")
+	}
+	c.Main.configFilePath = temp
+
+	time.Sleep(time.Millisecond * 10)
+
+	err = ioutil.WriteFile(testFile, []byte(tml), 0666)
+	if err != nil {
+		t.Error(err)
+	}
+
+	time.Sleep(time.Millisecond * 10)
+
+	c.ReloadConfig = nil
+	if !c.IsStale() {
+		t.Error("expected stale config")
+	}
+
+	time.Sleep(time.Millisecond * 10)
+
+	if c.IsStale() {
+		t.Error("expected non-stale config")
+	}
+}
+
+func TestConfigFilePath(t *testing.T) {
+
+	c, _ := emptyTestConfig()
+
+	if c.ConfigFilePath() != emptyFilePath {
+		t.Errorf("expected %s got %s", emptyFilePath, c.ConfigFilePath())
+	}
+
+	c.Main = nil
+	if c.ConfigFilePath() != "" {
+		t.Errorf("expected %s got %s", "", c.ConfigFilePath())
+	}
+
+}
+
+func TestFrontendConfigEqual(t *testing.T) {
+
+	f1 := &FrontendConfig{}
+	f2 := &FrontendConfig{}
+
+	b := f1.Equal(f2)
+	if !b {
+		t.Errorf("expected %t got %t", true, b)
 	}
 
 }

--- a/pkg/config/defaults/defaults.go
+++ b/pkg/config/defaults/defaults.go
@@ -120,6 +120,8 @@ const (
 	DefaultConfigHandlerPath = "/trickster/config"
 	// DefaultPingHandlerPath is the default value for the Trickster Config Ping Handler path
 	DefaultPingHandlerPath = "/trickster/ping"
+	// DefaultReloadHandlerPath defines the defaupt path for the Reload Handler
+	DefaultReloadHandlerPath = "/trickster/config/reload"
 	// DefaultMaxRuleExecutions is the default value for the number of allowed Rule executions per Request
 	DefaultMaxRuleExecutions = 16
 	// DefaultConfigPath defines the default location of the Trickster config file

--- a/pkg/config/defaults/defaults.go
+++ b/pkg/config/defaults/defaults.go
@@ -49,9 +49,9 @@ const (
 	DefaultReloadPort = 8484
 	// DefaultReloadAddress is the default address that the Reload endpoint will listen on
 	DefaultReloadAddress = "127.0.0.1"
-	// DefaultBleedTimeoutSecs is the default time that is allowed for an old configuration's requests to bleed
+	// DefaultDrainTimeoutSecs is the default time that is allowed for an old configuration's requests to drain
 	// before its resources are closed
-	DefaultBleedTimeoutSecs = 30
+	DefaultDrainTimeoutSecs = 30
 	// DefaultRateLimitSecs is the default Rate Limit time for Config Reloads
 	DefaultRateLimitSecs = 3
 

--- a/pkg/config/defaults/defaults.go
+++ b/pkg/config/defaults/defaults.go
@@ -45,6 +45,16 @@ const (
 	// DefaultTLSProxyListenAddress is the default address that the TLS frontend endpoint will listen on
 	DefaultTLSProxyListenAddress = ""
 
+	// DefaultReloadPort is the default port that the Reload endpoint will listen on
+	DefaultReloadPort = 8484
+	// DefaultReloadAddress is the default address that the Reload endpoint will listen on
+	DefaultReloadAddress = "127.0.0.1"
+	// DefaultBleedTimeoutSecs is the default time that is allowed for an old configuration's requests to bleed
+	// before its resources are closed
+	DefaultBleedTimeoutSecs = 30
+	// DefaultRateLimitSecs is the default Rate Limit time for Config Reloads
+	DefaultRateLimitSecs = 3
+
 	// DefaultTracerImplemetation is the default distributed tracer implementation
 	DefaultTracerImplemetation = "opentelemetry"
 	// DefaultExporterImplementation is the default distributed tracer exporter implementation

--- a/pkg/config/defaults/defaults.go
+++ b/pkg/config/defaults/defaults.go
@@ -126,6 +126,8 @@ const (
 	DefaultMaxRuleExecutions = 16
 	// DefaultConfigPath defines the default location of the Trickster config file
 	DefaultConfigPath = "/etc/trickster/trickster.conf"
+	// DefaultPprofServerName defines the default Pprof Server Name
+	DefaultPprofServerName = "both"
 )
 
 // DefaultCompressableTypes returns a list of types that Trickster should compress before caching

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -30,7 +30,7 @@ const (
 	evLogLevel    = "TRK_LOG_LEVEL"
 )
 
-func (c *TricksterConfig) loadEnvVars() {
+func (c *Config) loadEnvVars() {
 	// Origin
 	if x := os.Getenv(evOriginURL); x != "" {
 		c.providedOriginURL = x

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -84,7 +84,7 @@ func parseFlags(applicationName string, arguments []string) (*Flags, error) {
 }
 
 // loadFlags loads configuration from command line flags.
-func (c *TricksterConfig) loadFlags(flags *Flags) {
+func (c *Config) loadFlags(flags *Flags) {
 	if len(flags.Origin) > 0 {
 		c.providedOriginURL = flags.Origin
 	}

--- a/pkg/config/flags.go
+++ b/pkg/config/flags.go
@@ -26,6 +26,7 @@ const (
 	// Command-line flags
 	cfConfig      = "config"
 	cfVersion     = "version"
+	cfValidate    = "validate-config"
 	cfLogLevel    = "log-level"
 	cfInstanceID  = "instance-id"
 	cfOrigin      = "origin-url"
@@ -38,6 +39,7 @@ const (
 // Flags holds the values for whitelisted flags
 type Flags struct {
 	PrintVersion      bool
+	ValidateConfig    bool
 	ConfigPath        string
 	customPath        bool
 	Origin            string
@@ -57,14 +59,15 @@ func parseFlags(applicationName string, arguments []string) (*Flags, error) {
 	flags := &Flags{}
 	flagSet := flag.NewFlagSet("trickster", flag.ContinueOnError)
 
-	flagSet.BoolVar(&flags.PrintVersion, cfVersion, false, "Prints trickster version")
+	flagSet.BoolVar(&flags.PrintVersion, cfVersion, false, "Prints the Trickster version")
+	flagSet.BoolVar(&flags.ValidateConfig, cfValidate, false, "Validates a Trickster config and exits without running the server")
 	flagSet.StringVar(&flags.ConfigPath, cfConfig, "", "Path to Trickster Config File")
 	flagSet.StringVar(&flags.LogLevel, cfLogLevel, "", "Level of Logging to use (debug, info, warn, error)")
-	flagSet.IntVar(&flags.InstanceID, cfInstanceID, 0, "Instance ID is for running multiple Trickster processes from the same config while logging to their own files.")
+	flagSet.IntVar(&flags.InstanceID, cfInstanceID, 0, "Instance ID is for running multiple Trickster processes from the same config while logging to their own files")
 	flagSet.StringVar(&flags.Origin, cfOrigin, "", "URL to the Origin. Enter it like you would in grafana, e.g., http://prometheus:9090")
 	flagSet.StringVar(&flags.OriginType, cfOriginType, "", "Type of origin (prometheus, influxdb)")
-	flagSet.IntVar(&flags.ProxyListenPort, cfProxyPort, 0, "Port that the primary Proxy server will listen on.")
-	flagSet.IntVar(&flags.MetricsListenPort, cfMetricsPort, 0, "Port that the /metrics endpoint will listen on.")
+	flagSet.IntVar(&flags.ProxyListenPort, cfProxyPort, 0, "Port that the primary Proxy server will listen on")
+	flagSet.IntVar(&flags.MetricsListenPort, cfMetricsPort, 0, "Port that the /metrics endpoint will listen on")
 	//flagSet.IntVar(&flags.ReloadListenPort, cfReloadPort, 0, "Port that the /-/reload endpoint will listen on.")
 
 	var err error

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -37,9 +37,7 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 	if flags.PrintVersion {
 		return nil, flags, nil
 	}
-	if err := c.loadFile(flags); err == nil {
-		c.Main.ConfigFilePath = flags.ConfigPath
-	} else if flags.customPath {
+	if err := c.loadFile(flags); err != nil && flags.customPath {
 		// a user-provided path couldn't be loaded. return the error for the application to handle
 		return nil, flags, err
 	}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -32,14 +32,16 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 	c := NewConfig()
 	flags, err := parseFlags(applicationName, arguments) // Parse here to get config file path and version flags
 	if err != nil {
-		return nil, nil, err
+		return nil, flags, err
 	}
 	if flags.PrintVersion {
 		return nil, flags, nil
 	}
-	if err := c.loadFile(flags); err != nil && flags.customPath {
+	if err := c.loadFile(flags); err == nil {
+		c.Main.ConfigFilePath = flags.ConfigPath
+	} else if flags.customPath {
 		// a user-provided path couldn't be loaded. return the error for the application to handle
-		return nil, nil, err
+		return nil, flags, err
 	}
 
 	c.loadEnvVars()
@@ -50,7 +52,7 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 		if c.providedOriginURL != "" {
 			url, err := url.Parse(c.providedOriginURL)
 			if err != nil {
-				return nil, nil, err
+				return nil, flags, err
 			}
 			if c.providedOriginType != "" {
 				d.OriginType = c.providedOriginType
@@ -72,17 +74,17 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 	}
 
 	if len(c.Origins) == 0 {
-		return nil, nil, errors.New("no valid origins configured")
+		return nil, flags, errors.New("no valid origins configured")
 	}
 
 	for k, n := range c.NegativeCacheConfigs {
 		for c := range n {
 			ci, err := strconv.Atoi(c)
 			if err != nil {
-				return nil, nil, fmt.Errorf(`invalid negative cache config in %s: %s is not a valid status code`, k, c)
+				return nil, flags, fmt.Errorf(`invalid negative cache config in %s: %s is not a valid status code`, k, c)
 			}
 			if ci < 400 || ci >= 600 {
-				return nil, nil, fmt.Errorf(`invalid negative cache config in %s: %s is not a valid status code`, k, c)
+				return nil, flags, fmt.Errorf(`invalid negative cache config in %s: %s is not a valid status code`, k, c)
 			}
 		}
 	}
@@ -90,20 +92,20 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 	for k, o := range c.Origins {
 
 		if o.OriginType == "" {
-			return nil, nil, fmt.Errorf(`missing origin-type for origin "%s"`, k)
+			return nil, flags, fmt.Errorf(`missing origin-type for origin "%s"`, k)
 		}
 
 		if o.OriginType == "rule" && o.RuleName == "" {
-			return nil, nil, fmt.Errorf(`missing rule-name for origin "%s"`, k)
+			return nil, flags, fmt.Errorf(`missing rule-name for origin "%s"`, k)
 		}
 
 		if o.OriginType != "rule" && o.OriginURL == "" {
-			return nil, nil, fmt.Errorf(`missing origin-url for origin "%s"`, k)
+			return nil, flags, fmt.Errorf(`missing origin-url for origin "%s"`, k)
 		}
 
 		url, err := url.Parse(o.OriginURL)
 		if err != nil {
-			return nil, nil, err
+			return nil, flags, err
 		}
 
 		if strings.HasSuffix(url.Path, "/") {
@@ -134,7 +136,7 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 
 		nc, ok := c.NegativeCacheConfigs[o.NegativeCacheName]
 		if !ok {
-			return nil, nil, fmt.Errorf(`invalid negative cache name: %s`, o.NegativeCacheName)
+			return nil, flags, fmt.Errorf(`invalid negative cache name: %s`, o.NegativeCacheName)
 		}
 
 		nc2 := map[int]time.Duration{}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -93,10 +93,6 @@ func Load(applicationName string, applicationVersion string, arguments []string)
 			return nil, flags, fmt.Errorf(`missing origin-type for origin "%s"`, k)
 		}
 
-		if o.OriginType == "rule" && o.RuleName == "" {
-			return nil, flags, fmt.Errorf(`missing rule-name for origin "%s"`, k)
-		}
-
 		if o.OriginType != "rule" && o.OriginURL == "" {
 			return nil, flags, fmt.Errorf(`missing origin-url for origin "%s"`, k)
 		}

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -27,7 +27,7 @@ import (
 
 // Load returns the Application Configuration, starting with a default config,
 // then overriding with any provided config file, then env vars, and finally flags
-func Load(applicationName string, applicationVersion string, arguments []string) (*TricksterConfig, *Flags, error) {
+func Load(applicationName string, applicationVersion string, arguments []string) (*Config, *Flags, error) {
 
 	c := NewConfig()
 	flags, err := parseFlags(applicationName, arguments) // Parse here to get config file path and version flags

--- a/pkg/config/reload/options/options.go
+++ b/pkg/config/reload/options/options.go
@@ -30,9 +30,6 @@ type Options struct {
 	// BleedTimeoutSecs provides the duration to wait for all sessions to bleed before closing
 	// old resources following a reload
 	BleedTimeoutSecs int `toml:"bleed_timeout_secs"`
-	// FrontendRouting, when set to true, will expose the Reload Handler at ReloadHandlerPath on
-	// the main frontend proxy port, in addition to any configured listener in this ReloadConfig
-	FrontendRouting bool `toml:"frontend_routing"`
 	// RateLimitSecs limits the # of handled config reload HTTP requests to 1 per CheckRateSecs
 	// if multiple HTTP requests are received in the rate limit window, only the first is handled
 	// This prevents a bad actor from stating the config file with millions of concurrent requets

--- a/pkg/config/reload/options/options.go
+++ b/pkg/config/reload/options/options.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package reload helps with reloading the running Trickster configuration
+package options
+
+import "github.com/tricksterproxy/trickster/pkg/config/defaults"
+
+// Options is a collection of configurations for in-process config reloading
+type Options struct {
+	// ListenAddress is IP address from which the Reload API is available at ReloadHandlerPath
+	ListenAddress string `toml:"listen_address"`
+	// ListenPort is TCP Port from which the Reload API is available at ReloadHandlerPath
+	ListenPort int `toml:"listen_port"`
+	// ReloadHandlerPath provides the path to register the Config Reload Handler
+	HandlerPath string `toml:"handler_path"`
+	// BleedTimeoutSecs provides the duration to wait for all sessions to bleed before closing
+	// old resources following a reload
+	BleedTimeoutSecs int `toml:"bleed_timeout_secs"`
+	// FrontendRouting, when set to true, will expose the Reload Handler at ReloadHandlerPath on
+	// the main frontend proxy port, in addition to any configured listener in this ReloadConfig
+	FrontendRouting bool `toml:"frontend_routing"`
+	// RateLimitSecs limits the # of handled config reload HTTP requests to 1 per CheckRateSecs
+	// if multiple HTTP requests are received in the rate limit window, only the first is handled
+	// This prevents a bad actor from stating the config file with millions of concurrent requets
+	// The rate limit does not apply to SIGHUP-based reload requests
+	RateLimitSecs int `toml:"rate_limit_secs"`
+}
+
+// NewOptions returns a new Options references with Default Values set
+func NewOptions() *Options {
+	return &Options{
+		ListenAddress:    defaults.DefaultReloadAddress,
+		ListenPort:       defaults.DefaultReloadPort,
+		HandlerPath:      defaults.DefaultReloadHandlerPath,
+		BleedTimeoutSecs: defaults.DefaultBleedTimeoutSecs,
+		RateLimitSecs:    defaults.DefaultRateLimitSecs,
+	}
+}

--- a/pkg/config/reload/options/options.go
+++ b/pkg/config/reload/options/options.go
@@ -27,9 +27,9 @@ type Options struct {
 	ListenPort int `toml:"listen_port"`
 	// ReloadHandlerPath provides the path to register the Config Reload Handler
 	HandlerPath string `toml:"handler_path"`
-	// BleedTimeoutSecs provides the duration to wait for all sessions to bleed before closing
+	// DrainTimeoutSecs provides the duration to wait for all sessions to drain before closing
 	// old resources following a reload
-	BleedTimeoutSecs int `toml:"bleed_timeout_secs"`
+	DrainTimeoutSecs int `toml:"drain_timeout_secs"`
 	// RateLimitSecs limits the # of handled config reload HTTP requests to 1 per CheckRateSecs
 	// if multiple HTTP requests are received in the rate limit window, only the first is handled
 	// This prevents a bad actor from stating the config file with millions of concurrent requets
@@ -43,7 +43,7 @@ func NewOptions() *Options {
 		ListenAddress:    defaults.DefaultReloadAddress,
 		ListenPort:       defaults.DefaultReloadPort,
 		HandlerPath:      defaults.DefaultReloadHandlerPath,
-		BleedTimeoutSecs: defaults.DefaultBleedTimeoutSecs,
+		DrainTimeoutSecs: defaults.DefaultDrainTimeoutSecs,
 		RateLimitSecs:    defaults.DefaultRateLimitSecs,
 	}
 }

--- a/pkg/config/reload/options/options_test.go
+++ b/pkg/config/reload/options/options_test.go
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o != nil {
+		t.Error("expected non-nil options")
+	}
+}

--- a/pkg/config/reload/options/options_test.go
+++ b/pkg/config/reload/options/options_test.go
@@ -20,7 +20,7 @@ import "testing"
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
-	if o != nil {
+	if o == nil {
 		t.Error("expected non-nil options")
 	}
 }

--- a/pkg/config/reload/reload.go
+++ b/pkg/config/reload/reload.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package reload helps with reloading the running Trickster configuration
+package reload
+
+import (
+	"sync"
+
+	"github.com/tricksterproxy/trickster/pkg/config"
+	"github.com/tricksterproxy/trickster/pkg/util/log"
+)
+
+// ReloaderFunc describes a function that loads and applies a Trickster config at startup,
+// or gracefully over an existing running Config
+type ReloaderFunc func(oldConf *config.Config, wg *sync.WaitGroup, log *log.Logger, args []string, errorsFatal bool)

--- a/pkg/config/reload/reload.go
+++ b/pkg/config/reload/reload.go
@@ -20,10 +20,12 @@ package reload
 import (
 	"sync"
 
+	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/config"
 	"github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
 // ReloaderFunc describes a function that loads and applies a Trickster config at startup,
 // or gracefully over an existing running Config
-type ReloaderFunc func(oldConf *config.Config, wg *sync.WaitGroup, log *log.Logger, args []string, errorsFatal bool)
+type ReloaderFunc func(oldConf *config.Config, wg *sync.WaitGroup, log *log.Logger,
+	caches map[string]cache.Cache, args []string, errorsFatal bool)

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -43,13 +43,11 @@ func (c *Config) TLSCertConfig() (*tls.Config, error) {
 	tlsConfig := &tls.Config{NextProtos: []string{"h2"}}
 	tlsConfig.Certificates = make([]tls.Certificate, l)
 
-	i := 0
-	for _, tc := range to {
+	for i, tc := range to {
 		tlsConfig.Certificates[i], err = tls.LoadX509KeyPair(tc.TLS.FullChainCertPath, tc.TLS.PrivateKeyPath)
 		if err != nil {
 			return nil, err
 		}
-		i++
 	}
 
 	tlsConfig.BuildNameToCertificate()

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -23,7 +23,7 @@ import (
 )
 
 // TLSCertConfig returns the crypto/tls configuration object with a list of name-bound certs derifed from the running config
-func (c *TricksterConfig) TLSCertConfig() (*tls.Config, error) {
+func (c *Config) TLSCertConfig() (*tls.Config, error) {
 	var err error
 	if !c.Frontend.ServeTLS {
 		return nil, nil

--- a/pkg/locks/locks.go
+++ b/pkg/locks/locks.go
@@ -1,17 +1,14 @@
-/*
- * Copyright 2018 Comcast Cable Communications Management, LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+* Copyright 2018 Comcast Cable Communications Management, LLC
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
  */
 
 // Package locks provides Named Locks functionality for manging
@@ -19,6 +16,7 @@
 package locks
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -26,53 +24,52 @@ var locks = make(map[string]*namedLock)
 var mapLock = sync.Mutex{}
 
 type namedLock struct {
+	*sync.Mutex
 	name      string
-	mtx       *sync.Mutex
 	queueSize int
 }
 
 func newNamedLock(name string) *namedLock {
 	return &namedLock{
-		name: name,
-		mtx:  &sync.Mutex{},
+		name:  name,
+		Mutex: &sync.Mutex{},
 	}
 }
 
 // Acquire returns a named lock, and blocks until it is acquired
-func Acquire(lockName string) *sync.Mutex {
-
-	var nl *namedLock
-	var ok bool
-
+func Acquire(lockName string) error {
 	if lockName == "" {
-		return nil
+		return fmt.Errorf("invalid lock name: %s", lockName)
 	}
 
 	mapLock.Lock()
-	if nl, ok = locks[lockName]; !ok {
+	nl, ok := locks[lockName]
+	if !ok {
 		nl = newNamedLock(lockName)
 		locks[lockName] = nl
 	}
 	nl.queueSize++
 	mapLock.Unlock()
-	nl.mtx.Lock()
-	return nl.mtx
+
+	nl.Lock()
+	return nil
 }
 
 // Release unlocks and releases a named lock
-func Release(lockName string) {
-
+func Release(lockName string) error {
 	if lockName == "" {
-		return
+		return fmt.Errorf("invalid lock name: %s", lockName)
 	}
-
 	mapLock.Lock()
 	if nl, ok := locks[lockName]; ok {
 		nl.queueSize--
 		if nl.queueSize == 0 {
 			delete(locks, lockName)
 		}
-		nl.mtx.Unlock()
+		mapLock.Unlock()
+		nl.Unlock()
+		return nil
 	}
 	mapLock.Unlock()
+	return fmt.Errorf("no such lock name: %s", lockName)
 }

--- a/pkg/proxy/engines/access_logs.go
+++ b/pkg/proxy/engines/access_logs.go
@@ -22,7 +22,7 @@ import (
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
-func logUpstreamRequest(log *tl.TricksterLogger, originName, originType, handlerName, method, path, userAgent string, responseCode, size int, requestDuration float64) {
+func logUpstreamRequest(log *tl.Logger, originName, originType, handlerName, method, path, userAgent string, responseCode, size int, requestDuration float64) {
 	log.Debug("upstream request",
 		tl.Pairs{
 			"originName":  originName,
@@ -37,7 +37,7 @@ func logUpstreamRequest(log *tl.TricksterLogger, originName, originType, handler
 		})
 }
 
-func logDownstreamRequest(log *tl.TricksterLogger, r *http.Request) {
+func logDownstreamRequest(log *tl.Logger, r *http.Request) {
 	log.Debug("downtream request",
 		tl.Pairs{
 			"uri":       r.RequestURI,

--- a/pkg/proxy/engines/access_logs_test.go
+++ b/pkg/proxy/engines/access_logs_test.go
@@ -31,7 +31,7 @@ func TestLogUpstreamRequest(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	log := tl.Init(conf)
+	log := tl.New(conf)
 	logUpstreamRequest(log, "testOrigin", "testType", "testHandler", "testMethod", "testPath", "testUserAgent", 200, 0, 1.0)
 	if _, err := os.Stat(fileName); err != nil {
 		t.Errorf(err.Error())
@@ -46,7 +46,7 @@ func TestLogDownstreamRequest(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	log := tl.Init(conf)
+	log := tl.New(conf)
 	r, err := http.NewRequest("get", "http://testOrigin", nil)
 	if err != nil {
 		t.Error(err)

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -225,7 +225,7 @@ func WriteCache(ctx context.Context, c cache.Cache, key string, d *HTTPDocument,
 }
 
 // DocumentFromHTTPResponse returns an HTTPDocument from the provided HTTP Response and Body
-func DocumentFromHTTPResponse(resp *http.Response, body []byte, cp *CachingPolicy, log *tl.TricksterLogger) *HTTPDocument {
+func DocumentFromHTTPResponse(resp *http.Response, body []byte, cp *CachingPolicy, log *tl.Logger) *HTTPDocument {
 	d := &HTTPDocument{}
 	d.StatusCode = resp.StatusCode
 	d.Status = resp.Status

--- a/pkg/proxy/engines/cache_test.go
+++ b/pkg/proxy/engines/cache_test.go
@@ -456,8 +456,8 @@ func (tc *testCache) Retrieve(cacheKey string, allowExpired bool) ([]byte, statu
 	return nil, status.LookupStatusError, errTest
 }
 
-func (tc *testCache) SetTTL(cacheKey string, ttl time.Duration)  {}
-func (tc *testCache) Remove(cacheKey string)                     {}
-func (tc *testCache) BulkRemove(cacheKeys []string, noLock bool) {}
-func (tc *testCache) Close() error                               { return errTest }
-func (tc *testCache) Configuration() *co.Options                 { return tc.configuration }
+func (tc *testCache) SetTTL(cacheKey string, ttl time.Duration) {}
+func (tc *testCache) Remove(cacheKey string)                    {}
+func (tc *testCache) BulkRemove(cacheKeys []string)             {}
+func (tc *testCache) Close() error                              { return errTest }
+func (tc *testCache) Configuration() *co.Options                { return tc.configuration }

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -98,7 +98,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	client.SetExtent(r, trq, &trq.Extent)
+	client.SetExtent(pr.upstreamRequest, trq, &trq.Extent)
 	key := oc.CacheKeyPrefix + "." + pr.DeriveCacheKey(trq.TemplateURL, "")
 
 	locks.Acquire(key)
@@ -238,7 +238,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 			defer wg.Done()
 			rq.Request = rq.WithContext(tctx.WithResources(r.Context(),
 				request.NewResources(oc, pc, cc, cache, client, pr.Logger)))
-			client.SetExtent(rq.Request, trq, e)
+			client.SetExtent(rq.upstreamRequest, trq, e)
 			body, resp, _ := rq.Fetch()
 			if resp.StatusCode == http.StatusOK && len(body) > 0 {
 				nts, err := client.UnmarshalTimeseries(body)

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -371,7 +371,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 	locks.Release(key)
 }
 
-func logDeltaRoutine(log *tl.TricksterLogger, p tl.Pairs) { log.Debug("delta routine completed", p) }
+func logDeltaRoutine(log *tl.Logger, p tl.Pairs) { log.Debug("delta routine completed", p) }
 
 func fetchTimeseries(pr *proxyRequest, trq *timeseries.TimeRangeQuery, client origins.TimeseriesClient) (timeseries.Timeseries, *HTTPDocument, time.Duration, error) {
 

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -108,7 +108,7 @@ func (d *HTTPDocument) LoadRangeParts() {
 }
 
 // ParsePartialContentBody parses a Partial Content response body into 0 or more discrete parts
-func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response, body []byte, log *tl.TricksterLogger) {
+func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response, body []byte, log *tl.Logger) {
 
 	ct := resp.Header.Get(headers.NameContentType)
 	if cr := resp.Header.Get(headers.NameContentRange); cr != "" {

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -245,7 +245,7 @@ func handleCacheKeyMiss(pr *proxyRequest) error {
 			return nil
 		}
 
-		reader, resp, contentLength := PrepareFetchReader(pr.Request)
+		reader, resp, contentLength := PrepareFetchReader(pr.upstreamRequest)
 		pr.upstreamResponse = resp
 
 		pr.writeResponseHeader()

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -74,7 +74,7 @@ type proxyRequest struct {
 	collapsedForwarder ProgressiveCollapseForwarder
 	cachingPolicy      *CachingPolicy
 
-	Logger *tl.TricksterLogger
+	Logger *tl.Logger
 	isPCF  bool
 }
 

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -81,26 +81,24 @@ type proxyRequest struct {
 // newProxyRequest accepts the original inbound HTTP Request and Response
 // and returns a proxyRequest object
 func newProxyRequest(r *http.Request, w io.Writer) *proxyRequest {
-
 	rsc := request.GetResources(r)
-
 	pr := &proxyRequest{
 		Request:         r,
 		Logger:          rsc.Logger,
-		upstreamRequest: r.Clone(context.Background()),
+		upstreamRequest: r.Clone(tctx.WithResources(context.Background(), rsc)),
 		contentLength:   -1,
 		responseWriter:  w,
 		started:         time.Now(),
 	}
-
-	pr.upstreamRequest = pr.upstreamRequest.WithContext(tctx.WithResources(pr.upstreamRequest.Context(), rsc))
-
 	return pr
 }
 
 func (pr *proxyRequest) Clone() *proxyRequest {
+	rsc := request.GetResources(pr.Request)
 	return &proxyRequest{
-		Request:            pr.Request.Clone(context.Background()),
+		Request: pr.Request.Clone(context.Background()),
+		upstreamRequest: pr.upstreamRequest.
+			Clone(tctx.WithResources(context.Background(), rsc)),
 		Logger:             pr.Logger,
 		cacheDocument:      pr.cacheDocument,
 		key:                pr.key,
@@ -122,7 +120,7 @@ func (pr *proxyRequest) Clone() *proxyRequest {
 // response and elapsed time to the caller.
 func (pr *proxyRequest) Fetch() ([]byte, *http.Response, time.Duration) {
 
-	rsc := request.GetResources(pr.Request)
+	rsc := request.GetResources(pr.upstreamRequest)
 	oc := rsc.OriginConfig
 	pc := rsc.PathConfig
 
@@ -132,7 +130,7 @@ func (pr *proxyRequest) Fetch() ([]byte, *http.Response, time.Duration) {
 	}
 
 	start := time.Now()
-	reader, resp, _ := PrepareFetchReader(pr.Request)
+	reader, resp, _ := PrepareFetchReader(pr.upstreamRequest)
 
 	var body []byte
 	var err error

--- a/pkg/proxy/handlers/ping.go
+++ b/pkg/proxy/handlers/ping.go
@@ -23,19 +23,6 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 )
 
-// RegisterPingHandler registers the application's /ping handler
-// func RegisterPingHandler() {
-// 	routing.Router.HandleFunc(config.Main.PingHandlerPath, pingHandler).Methods("GET")
-// }
-
-// // pingHandler responds to an HTTP Request with 200 OK and "pong"
-// func pingHandler(w http.ResponseWriter, r *http.Request) {
-// 	w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
-// 	w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
-// 	w.WriteHeader(http.StatusOK)
-// 	w.Write([]byte("pong"))
-// }
-
 // PingHandleFunc responds to an HTTP Request with 200 OK and "pong"
 func PingHandleFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/proxy/handlers/ping.go
+++ b/pkg/proxy/handlers/ping.go
@@ -37,7 +37,7 @@ import (
 // }
 
 // PingHandleFunc responds to an HTTP Request with 200 OK and "pong"
-func PingHandleFunc(conf *config.TricksterConfig) func(http.ResponseWriter, *http.Request) {
+func PingHandleFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)

--- a/pkg/proxy/handlers/reload.go
+++ b/pkg/proxy/handlers/reload.go
@@ -36,6 +36,7 @@ func ReloadHandleFunc(f reload.ReloaderFunc, conf *config.Config, wg *sync.WaitG
 			w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte("configuration reloaded"))
+			return
 		}
 		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)

--- a/pkg/proxy/handlers/reload.go
+++ b/pkg/proxy/handlers/reload.go
@@ -18,19 +18,28 @@ package handlers
 
 import (
 	"net/http"
+	"sync"
 
 	"github.com/tricksterproxy/trickster/pkg/config"
+	"github.com/tricksterproxy/trickster/pkg/config/reload"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
+	"github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
 // ReloadHandleFunc will reload the running configuration if it has changed
-func ReloadHandleFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
-
+func ReloadHandleFunc(f reload.ReloaderFunc, conf *config.Config, wg *sync.WaitGroup,
+	log *log.Logger, args []string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if conf.IsStale() {
+			f(conf, wg, log, args, false)
+			w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
+			w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("configuration reloaded"))
+		}
 		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(conf.String()))
+		w.Write([]byte("configuration NOT reloaded"))
 	}
-
 }

--- a/pkg/proxy/handlers/reload.go
+++ b/pkg/proxy/handlers/reload.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/config"
 	"github.com/tricksterproxy/trickster/pkg/config/reload"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
@@ -28,10 +29,11 @@ import (
 
 // ReloadHandleFunc will reload the running configuration if it has changed
 func ReloadHandleFunc(f reload.ReloaderFunc, conf *config.Config, wg *sync.WaitGroup,
-	log *log.Logger, args []string) func(http.ResponseWriter, *http.Request) {
+	log *log.Logger, caches map[string]cache.Cache, args []string) func(http.ResponseWriter,
+	*http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if conf.IsStale() {
-			f(conf, wg, log, args, false)
+			f(conf, wg, log, caches, args, false)
 			w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 			w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
 			w.WriteHeader(http.StatusOK)

--- a/pkg/proxy/handlers/reload.go
+++ b/pkg/proxy/handlers/reload.go
@@ -23,12 +23,14 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 )
 
-// ConfigHandleFunc responds to the HTTP request with the running configuration
-func ConfigHandleFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
+// ReloadHandleFunc will reload the running configuration if it has changed
+func ReloadHandleFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
+
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(conf.String()))
 	}
+
 }

--- a/pkg/proxy/handlers/reload.go
+++ b/pkg/proxy/handlers/reload.go
@@ -24,15 +24,16 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/config"
 	"github.com/tricksterproxy/trickster/pkg/config/reload"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
-	"github.com/tricksterproxy/trickster/pkg/util/log"
+	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
 // ReloadHandleFunc will reload the running configuration if it has changed
 func ReloadHandleFunc(f reload.ReloaderFunc, conf *config.Config, wg *sync.WaitGroup,
-	log *log.Logger, caches map[string]cache.Cache, args []string) func(http.ResponseWriter,
+	log *tl.Logger, caches map[string]cache.Cache, args []string) func(http.ResponseWriter,
 	*http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if conf.IsStale() {
+			log.Warn("configuration reload starting now", tl.Pairs{"source": "reloadEndpoint"})
 			f(conf, wg, log, caches, args, false)
 			w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 			w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)

--- a/pkg/proxy/handlers/reload_test.go
+++ b/pkg/proxy/handlers/reload_test.go
@@ -37,7 +37,7 @@ func TestReloadHandleFunc(t *testing.T) {
 		map[string]cache.Cache, []string, bool) {
 	}
 
-	testFile := fmt.Sprintf("/tmp/trickster_test_config.%d.conf", time.Now().UnixNano())
+	testFile := fmt.Sprintf("trickster_test_config.%d.conf", time.Now().UnixNano())
 
 	tml, err := ioutil.ReadFile("../../../testdata/test.empty.conf")
 	if err != nil {
@@ -58,7 +58,7 @@ func TestReloadHandleFunc(t *testing.T) {
 
 	f := ReloadHandleFunc(emptyFunc, cfg, nil, log, nil, nil)
 	f(w, r)
-	ioutil.WriteFile(testFile, tml, 0666)
+	ioutil.WriteFile(testFile, []byte(string(tml)+" "), 0666)
 	f(w, r)
 
 }

--- a/pkg/proxy/handlers/reload_test.go
+++ b/pkg/proxy/handlers/reload_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handlers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tricksterproxy/trickster/pkg/cache"
+	"github.com/tricksterproxy/trickster/pkg/config"
+	tl "github.com/tricksterproxy/trickster/pkg/util/log"
+)
+
+func TestReloadHandleFunc(t *testing.T) {
+
+	var emptyFunc = func(*config.Config, *sync.WaitGroup, *tl.Logger,
+		map[string]cache.Cache, []string, bool) {
+	}
+
+	testFile := fmt.Sprintf("/tmp/trickster_test_config.%d.conf", time.Now().UnixNano())
+
+	tml, err := ioutil.ReadFile("../../../testdata/test.empty.conf")
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = ioutil.WriteFile(testFile, tml, 0666)
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(testFile)
+
+	cfg, _, _ := config.Load("testing", "testing", []string{"-config", testFile})
+	cfg.ReloadConfig.RateLimitSecs = 0
+	log := tl.ConsoleLogger("info")
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+
+	f := ReloadHandleFunc(emptyFunc, cfg, nil, log, nil, nil)
+	f(w, r)
+	ioutil.WriteFile(testFile, tml, 0666)
+	f(w, r)
+
+}

--- a/pkg/proxy/handlers/switch.go
+++ b/pkg/proxy/handlers/switch.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handlers
+
+import (
+	"net/http"
+	"sync/atomic"
+)
+
+// SwitchHandler is an HTTP Wrapper that allows users to update the underlying handler in-place
+// once associated with a net.Listener
+type SwitchHandler struct {
+	mux       http.Handler
+	oldMux    http.Handler
+	reloading int32
+}
+
+// NewSwitchHandler returns a New *SwitchHandler
+func NewSwitchHandler(router http.Handler) *SwitchHandler {
+	return &SwitchHandler{mux: router, oldMux: router}
+}
+
+// ServeHTTP serves an HTTP Request
+func (s *SwitchHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.isReloading() {
+		s.oldMux.ServeHTTP(w, r)
+		return
+	}
+	s.mux.ServeHTTP(w, r)
+}
+
+// Update atomically changes the underlying handler without impacting user requests or uptime
+func (s *SwitchHandler) Update(h http.Handler) {
+	s.oldMux = s.mux
+	s.setReloading(true)
+	s.mux = h
+	s.setReloading(false)
+}
+
+func (s *SwitchHandler) isReloading() bool {
+	return atomic.LoadInt32(&s.reloading) != 0
+}
+
+func (s *SwitchHandler) setReloading(isReloading bool) {
+	if isReloading {
+		atomic.StoreInt32(&s.reloading, 1)
+		return
+	}
+	atomic.StoreInt32(&s.reloading, 0)
+}

--- a/pkg/proxy/handlers/switch_test.go
+++ b/pkg/proxy/handlers/switch_test.go
@@ -14,28 +14,35 @@
  * limitations under the License.
  */
 
-package options
+package handlers
 
-import "testing"
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
 
-func TestNewOptions(t *testing.T) {
-	o := NewOptions()
-	if o != nil {
-		t.Error("expected non-nil options")
+func TestNewSwitchHandler(t *testing.T) {
+	router := http.NewServeMux()
+	sh := NewSwitchHandler(router)
+	if sh == nil {
+		t.Error("expected non-nill handler")
 	}
 }
 
-func TestCloneAndEqual(t *testing.T) {
+func TestServeHTTP(t *testing.T) {
+	router := http.NewServeMux()
+	sh := NewSwitchHandler(router)
+	w := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	sh.setReloading(true)
+	sh.ServeHTTP(w, r)
+	sh.setReloading(false)
+	sh.ServeHTTP(w, r)
+}
 
-	o := NewOptions()
-	o2 := o.Clone()
-
-	if !o.Equal(o2) {
-		t.Error("expected true")
-	}
-
-	if o.Equal(nil) {
-		t.Error("expected false")
-	}
-
+func TestUpdate(t *testing.T) {
+	router := http.NewServeMux()
+	sh := NewSwitchHandler(router)
+	sh.Update(router)
 }

--- a/pkg/proxy/origins/options/options.go
+++ b/pkg/proxy/origins/options/options.go
@@ -225,6 +225,7 @@ func (oc *Options) Clone() *Options {
 	o.OriginType = oc.OriginType
 	o.OriginURL = oc.OriginURL
 	o.PathPrefix = oc.PathPrefix
+	o.ReqRewriterName = oc.ReqRewriterName
 	o.RevalidationFactor = oc.RevalidationFactor
 	o.RuleName = oc.RuleName
 	o.Scheme = oc.Scheme

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -109,7 +109,7 @@ func NewHTTPClient(oc *oo.Options) (*http.Client, error) {
 // which observes the connections to set a gauge with the current number of
 // connections (with operates with sampling through scrapes), and a set of
 // counter metrics for connections accepted, rejected and closed.
-func NewListener(listenAddress string, listenPort, connectionsLimit int, tlsConfig *tls.Config, log *tl.TricksterLogger) (net.Listener, error) {
+func NewListener(listenAddress string, listenPort, connectionsLimit int, tlsConfig *tls.Config, log *tl.Logger) (net.Listener, error) {
 
 	var listener net.Listener
 	var err error

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -41,7 +41,7 @@ type Resources struct {
 	OriginClient      origins.Client
 	AlternateCacheTTL time.Duration
 	TimeRangeQuery    *timeseries.TimeRangeQuery
-	Logger            *tl.TricksterLogger
+	Logger            *tl.Logger
 }
 
 // Clone returns an exact copy of the subject Resources collection
@@ -61,7 +61,7 @@ func (r Resources) Clone() *Resources {
 
 // NewResources returns a new Resources collection based on the provided inputs
 func NewResources(oo *oo.Options, po *po.Options, co *co.Options,
-	c cache.Cache, client origins.Client, logger *tl.TricksterLogger) *Resources {
+	c cache.Cache, client origins.Client, logger *tl.Logger) *Resources {
 	return &Resources{
 		OriginConfig: oo,
 		PathConfig:   po,

--- a/pkg/proxy/request/rewriter/rewriter.go
+++ b/pkg/proxy/request/rewriter/rewriter.go
@@ -17,6 +17,7 @@
 package rewriter
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/tricksterproxy/trickster/pkg/proxy/request/rewriter/options"
@@ -25,6 +26,10 @@ import (
 // ProcessConfigs validates and compiles rewriter instructions from
 // the provided configuration map
 func ProcessConfigs(rwl map[string]*options.Options) (map[string]RewriteInstructions, error) {
+	if rwl == nil {
+		return nil, errors.New("invalid rewriter options")
+	}
+
 	crw := make(map[string]RewriteInstructions)
 	for k, v := range rwl {
 		ri, err := parseRewriteList(v.Instructions)

--- a/pkg/proxy/tls/options/options.go
+++ b/pkg/proxy/tls/options/options.go
@@ -18,6 +18,8 @@ package options
 
 import (
 	"io/ioutil"
+
+	"github.com/tricksterproxy/trickster/pkg/util/strings"
 )
 
 // Options is a collection of TLS-related client and server configurations
@@ -68,6 +70,16 @@ func (o *Options) Clone() *Options {
 		ClientCertPath:            o.ClientCertPath,
 		ClientKeyPath:             o.ClientKeyPath,
 	}
+}
+
+// Equal returns true if all TOML-exposed option members are equal
+func (o *Options) Equal(o2 *Options) bool {
+	return o.FullChainCertPath == o2.FullChainCertPath &&
+		o.PrivateKeyPath == o2.PrivateKeyPath &&
+		o.InsecureSkipVerify == o2.InsecureSkipVerify &&
+		strings.Equal(o.CertificateAuthorityPaths, o2.CertificateAuthorityPaths) &&
+		o.ClientCertPath == o2.ClientCertPath &&
+		o.ClientKeyPath == o2.ClientKeyPath
 }
 
 // Validate returns true if the TLS Options are validated

--- a/pkg/proxy/tls/swapper.go
+++ b/pkg/proxy/tls/swapper.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"crypto/tls"
+	"errors"
+	"sync"
+)
+
+// CertSwapper is used by a TLSConfig to dynamically update the running Listener's Certificate list
+// This allows Trickster to load and unload TLS certificate configs without restarting the process
+type CertSwapper struct {
+	sync.Mutex
+	Certificates []tls.Certificate
+}
+
+var errNoCertificates = errors.New("tls: no certificates configured")
+
+func (c *CertSwapper) GetCert(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	c.Lock()
+	defer c.Unlock()
+
+	if len(c.Certificates) == 0 {
+		return nil, errNoCertificates
+	}
+
+	if len(c.Certificates) == 1 {
+		// There's only one choice, so no point doing any work.
+		return &c.Certificates[0], nil
+	}
+
+	for _, cert := range c.Certificates {
+		if err := clientHello.SupportsCertificate(&cert); err == nil {
+			return &cert, nil
+		}
+	}
+
+	// If nothing matches, return the first certificate.
+	return &c.Certificates[0], nil
+}
+
+func (c *CertSwapper) SetCerts(certs []tls.Certificate) {
+	c.Lock()
+	defer c.Unlock()
+	c.Certificates = certs
+}

--- a/pkg/proxy/tls/swapper.go
+++ b/pkg/proxy/tls/swapper.go
@@ -25,11 +25,18 @@ import (
 // CertSwapper is used by a TLSConfig to dynamically update the running Listener's Certificate list
 // This allows Trickster to load and unload TLS certificate configs without restarting the process
 type CertSwapper struct {
-	sync.Mutex
+	*sync.Mutex
 	Certificates []tls.Certificate
 }
 
 var errNoCertificates = errors.New("tls: no certificates configured")
+
+func NewSwapper(certList []tls.Certificate) *CertSwapper {
+	return &CertSwapper{
+		Mutex:        &sync.Mutex{},
+		Certificates: certList,
+	}
+}
 
 func (c *CertSwapper) GetCert(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
 	c.Lock()

--- a/pkg/proxy/tls/swapper_test.go
+++ b/pkg/proxy/tls/swapper_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"crypto/tls"
+	"testing"
+)
+
+func getSwapper(id string, t *testing.T) (*CertSwapper, *tls.Config) {
+
+	var err error
+
+	options := tlsConfig(id)
+
+	tlscfg1 := &tls.Config{NextProtos: []string{"h2"}}
+	tlscfg1.Certificates = make([]tls.Certificate, 1)
+	tlscfg1.Certificates[0], err =
+		tls.LoadX509KeyPair(options.FullChainCertPath, options.PrivateKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return NewSwapper(tlscfg1.Certificates), tlscfg1
+
+}
+
+func TestGetSetCert(t *testing.T) {
+
+	chi := &tls.ClientHelloInfo{}
+	sw, cfg := getSwapper("01", t)
+	_, err := sw.GetCert(chi)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, cfg2 := getSwapper("02", t)
+	sw.Certificates = append(sw.Certificates, cfg2.Certificates...)
+	_, err = sw.GetCert(chi)
+	if err != nil {
+		t.Error(err)
+	}
+
+	sw.Certificates = nil
+	_, err = sw.GetCert(chi)
+	if err == nil || err.Error() != "tls: no certificates configured" {
+		t.Errorf("expected error for no certificates configured. %s", err.Error())
+	}
+	sw.SetCerts(cfg.Certificates)
+	_, err = sw.GetCert(chi)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/proxy/tls/tls_test.go
+++ b/pkg/proxy/tls/tls_test.go
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// set 		oc.TLS.ServeTLS = true
-
 package tls
 
 import (

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -46,8 +46,8 @@ import (
 
 // RegisterProxyRoutes iterates the Trickster Configuration and
 // registers the routes for the configured origins
-func RegisterProxyRoutes(conf *config.TricksterConfig, router *mux.Router,
-	caches map[string]cache.Cache, log *tl.TricksterLogger, dryRun bool) (origins.Origins, error) {
+func RegisterProxyRoutes(conf *config.Config, router *mux.Router,
+	caches map[string]cache.Cache, log *tl.Logger, dryRun bool) (origins.Origins, error) {
 
 	// a fake "top-level" origin representing the main frontend, so rules can route
 	// to it via the clients map
@@ -144,9 +144,9 @@ func validateRuleClients(clients origins.Origins,
 	return nil
 }
 
-func registerOriginRoutes(router *mux.Router, conf *config.TricksterConfig, k string,
+func registerOriginRoutes(router *mux.Router, conf *config.Config, k string,
 	o *oo.Options, clients origins.Origins, caches map[string]cache.Cache,
-	log *tl.TricksterLogger, dryRun bool) (origins.Origins, error) {
+	log *tl.Logger, dryRun bool) (origins.Origins, error) {
 
 	var client origins.Client
 	var c cache.Cache
@@ -193,7 +193,7 @@ func registerOriginRoutes(router *mux.Router, conf *config.TricksterConfig, k st
 // the path routes to the appropriate handler from the provided handlers map
 func registerPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 	client origins.Client, oo *oo.Options, c cache.Cache,
-	paths map[string]*po.Options, log *tl.TricksterLogger) {
+	paths map[string]*po.Options, log *tl.Logger) {
 
 	decorate := func(po *po.Options) http.Handler {
 		// add Origin, Cache, and Path Configs to the HTTP Request's context

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -20,6 +20,7 @@ package routing
 import (
 	"fmt"
 	"net/http"
+	"net/http/pprof"
 	"sort"
 	"strings"
 
@@ -43,6 +44,16 @@ import (
 
 	"github.com/gorilla/mux"
 )
+
+// RegisterPprofRoutes will register the Pprof Debugging endpoints to the provided router
+func RegisterPprofRoutes(routerName string, h *http.ServeMux, log *tl.Logger) {
+	log.Info("registering pprof /debug routes", tl.Pairs{"routerName": routerName})
+	h.HandleFunc("/debug/pprof/", pprof.Index)
+	h.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	h.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	h.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	h.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
 
 // RegisterProxyRoutes iterates the Trickster Configuration and
 // registers the routes for the configured origins

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -17,6 +17,7 @@
 package routing
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/tricksterproxy/trickster/pkg/cache/registration"
@@ -28,6 +29,17 @@ import (
 
 	"github.com/gorilla/mux"
 )
+
+func TestRegisterPprofRoutes(t *testing.T) {
+	router := http.NewServeMux()
+	log := tl.ConsoleLogger("info")
+	RegisterPprofRoutes("test", router, log)
+	r, _ := http.NewRequest("GET", "http://0/debug/pprof", nil)
+	_, p := router.Handler(r)
+	if p != "/debug/pprof/" {
+		t.Error("expected pprof route path")
+	}
+}
 
 func TestRegisterProxyRoutes(t *testing.T) {
 

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -40,7 +40,7 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	}
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	proxyClients, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, log)
+	proxyClients, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, log, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -49,7 +49,7 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	oc.Hosts = []string{"test", "test2"}
 
 	registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
-	RegisterProxyRoutes(conf, mux.NewRouter(), caches, log)
+	RegisterProxyRoutes(conf, mux.NewRouter(), caches, log, false)
 
 	if len(proxyClients) == 0 {
 		t.Errorf("expected %d got %d", 1, 0)
@@ -70,26 +70,26 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	conf.Origins["2"] = o2
 
 	router := mux.NewRouter()
-	_, err = RegisterProxyRoutes(conf, router, caches, log)
+	_, err = RegisterProxyRoutes(conf, router, caches, log, false)
 	if err == nil {
 		t.Errorf("Expected error for too many default origins.%s", "")
 	}
 
 	o1.IsDefault = false
-	_, err = RegisterProxyRoutes(conf, router, caches, log)
+	_, err = RegisterProxyRoutes(conf, router, caches, log, false)
 	if err != nil {
 		t.Error(err)
 	}
 
 	o2.IsDefault = false
 	o2.CacheName = "invalid"
-	_, err = RegisterProxyRoutes(conf, router, caches, log)
+	_, err = RegisterProxyRoutes(conf, router, caches, log, false)
 	if err == nil {
 		t.Errorf("Expected error for invalid cache name%s", "")
 	}
 
 	o2.CacheName = "default"
-	_, err = RegisterProxyRoutes(conf, router, caches, log)
+	_, err = RegisterProxyRoutes(conf, router, caches, log, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -102,7 +102,7 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	conf.Origins["1"] = o1
 	delete(conf.Origins, "default")
 
-	_, err = RegisterProxyRoutes(conf, router, caches, log)
+	_, err = RegisterProxyRoutes(conf, router, caches, log, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -117,7 +117,7 @@ func TestRegisterProxyRoutesInflux(t *testing.T) {
 
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -137,7 +137,7 @@ func TestRegisterProxyRoutesClickHouse(t *testing.T) {
 
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -157,7 +157,7 @@ func TestRegisterProxyRoutesIRONdb(t *testing.T) {
 
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -180,7 +180,7 @@ func TestRegisterProxyRoutesRules(t *testing.T) {
 
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	proxyClients, err := RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -201,7 +201,7 @@ func TestRegisterProxyRoutesMultipleDefaults(t *testing.T) {
 	}
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err == nil {
 		t.Errorf("expected error `%s` got nothing", expected1)
 	} else if err.Error() != expected1 && err.Error() != expected2 {
@@ -218,7 +218,7 @@ func TestRegisterProxyRoutesInvalidCert(t *testing.T) {
 	}
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err == nil {
 		t.Errorf("expected error: %s", expected)
 	}
@@ -247,7 +247,7 @@ func TestRegisterProxyRoutesBadOriginType(t *testing.T) {
 	}
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err == nil {
 		t.Errorf("expected error `%s` got nothing", expected)
 	} else if err.Error() != expected {
@@ -263,7 +263,7 @@ func TestRegisterMultipleOrigins(t *testing.T) {
 	}
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -277,7 +277,7 @@ func TestRegisterMultipleOriginsPlusDefault(t *testing.T) {
 	}
 	caches := registration.LoadCachesFromConfig(conf, tl.ConsoleLogger("error"))
 	defer registration.CloseCaches(caches)
-	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"))
+	_, err = RegisterProxyRoutes(conf, mux.NewRouter(), caches, tl.ConsoleLogger("info"), false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -113,10 +113,10 @@ func ConsoleLogger(logLevel string) *TricksterLogger {
 	return l
 }
 
-// Init returns a TricksterLogger for the provided logging configuration. The
+// New returns a TricksterLogger for the provided logging configuration. The
 // returned TricksterLogger will write to files distinguished from other TricksterLoggers by the
 // instance string.
-func Init(conf *config.TricksterConfig) *TricksterLogger {
+func New(conf *config.TricksterConfig) *TricksterLogger {
 
 	l := noopLogger()
 	var wr io.Writer

--- a/pkg/util/log/log.go
+++ b/pkg/util/log/log.go
@@ -123,7 +123,7 @@ func (tl *Logger) SetLogLevel(logLevel string) {
 // New returns a Logger for the provided logging configuration. The
 // returned Logger will write to files distinguished from other Loggers by the
 // instance string.
-func New(conf *config.TricksterConfig) *Logger {
+func New(conf *config.Config) *Logger {
 
 	l := noopLogger()
 	var wr io.Writer

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -260,3 +260,17 @@ func TestNewLoggerFatal_LogFile(t *testing.T) {
 	log.Close()
 	os.Remove(fileName)
 }
+
+func TestSetLogLevel(t *testing.T) {
+
+	l := DefaultLogger()
+	if l.level != "info" {
+		t.Errorf("expected %s got %s", "info", l.level)
+	}
+
+	l.SetLogLevel("warn")
+	if l.Level() != "warn" {
+		t.Errorf("expected %s got %s", "warn", l.level)
+	}
+
+}

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -44,12 +44,12 @@ func TestConsoleLogger(t *testing.T) {
 	}
 }
 
-func TestInit(t *testing.T) {
+func TestNew(t *testing.T) {
 
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogLevel: "info"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	if log.level != "info" {
 		t.Errorf("expected %s got %s", "info", log.level)
@@ -63,7 +63,7 @@ func TestNewLogger_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 1}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "info"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Info("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(instanceFileName); err != nil {
@@ -79,7 +79,7 @@ func TestNewLoggerDebug_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Debug("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
@@ -95,7 +95,7 @@ func TestNewLoggerWarn_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "warn"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Warn("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
@@ -111,7 +111,7 @@ func TestNewLoggerWarnOnce_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "x"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 
 	key := "warnonce-test-key"
@@ -151,7 +151,7 @@ func TestNewLoggerError_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "error"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Error("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
@@ -167,7 +167,7 @@ func TestNewLoggerErrorOnce_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "x"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 
 	ok := log.ErrorOnce("erroroonce-test-key", "test entry", Pairs{"testKey": "testVal"})
@@ -193,7 +193,7 @@ func TestNewLoggerTrace_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "trace"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Trace("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
@@ -209,7 +209,7 @@ func TestNewLoggerDefault_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "x"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Info("test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {
@@ -225,7 +225,7 @@ func TestNewLoggerInfoOnce_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "info"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	ok := log.InfoOnce("infoonce-test-key", "test entry", Pairs{"testKey": "testVal"})
 	if !ok {
@@ -251,7 +251,7 @@ func TestNewLoggerFatal_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "debug"}
-	log := Init(conf)
+	log := New(conf)
 	defer log.Close()
 	log.Fatal(-1, "test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(fileName); err != nil {

--- a/pkg/util/middleware/config_context.go
+++ b/pkg/util/middleware/config_context.go
@@ -30,7 +30,7 @@ import (
 
 // WithResourcesContext ...
 func WithResourcesContext(client origins.Client, oc *oo.Options,
-	c cache.Cache, p *po.Options, l *tl.TricksterLogger, next http.Handler) http.Handler {
+	c cache.Cache, p *po.Options, l *tl.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var resources *request.Resources
 		if c == nil {

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -35,3 +35,16 @@ func CloneMap(in map[string]string) map[string]string {
 	}
 	return out
 }
+
+// Equal returns true if the slices contain identical values in the identical order
+func Equal(s1, s2 []string) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i, v := range s1 {
+		if v != s2[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -51,3 +51,23 @@ func TestCloneMap(t *testing.T) {
 	}
 
 }
+
+func TestEqual(t *testing.T) {
+
+	l1 := []string{"test1", "test2"}
+	l2 := []string{"test1", "test2"}
+	l3 := []string{"test3", "test4"}
+	l4 := []string{}
+
+	if !Equal(l1, l2) {
+		t.Error("expected true got false")
+	}
+
+	if Equal(l1, l3) {
+		t.Error("expected false got true")
+	}
+
+	if Equal(l1, l4) {
+		t.Error("expected false got true")
+	}
+}

--- a/pkg/util/tracing/options/tracing.go
+++ b/pkg/util/tracing/options/tracing.go
@@ -83,6 +83,9 @@ func (teo *TracingExporterOptions) Clone() *TracingExporterOptions {
 
 // ProcessTracingConfigs enriches the configuration data of the provided Tracing Options collection
 func ProcessTracingConfigs(mo map[string]*Options, metadata *toml.MetaData) {
+	if metadata == nil {
+		return
+	}
 	for k, v := range mo {
 		if !metadata.IsDefined("tracing", k, "exporter") {
 			v.Exporter = &TracingExporterOptions{}

--- a/pkg/util/tracing/registration/registration.go
+++ b/pkg/util/tracing/registration/registration.go
@@ -34,7 +34,7 @@ type Flushers []func()
 
 // RegisterAll registers all Tracers in the provided configuration, and returns
 // their Flushers
-func RegisterAll(cfg *config.TricksterConfig, log *tl.TricksterLogger) (Flushers, error) {
+func RegisterAll(cfg *config.Config, log *tl.Logger) (Flushers, error) {
 
 	if cfg == nil {
 		return nil, errors.New("no config provided")
@@ -79,7 +79,7 @@ func RegisterAll(cfg *config.TricksterConfig, log *tl.TricksterLogger) (Flushers
 }
 
 // Init initializes tracing and returns a function to flush the tracer. Flush should be called on server shutdown.
-func Init(cfg *to.Options, log *tl.TricksterLogger) (trace.Tracer, func(), error) {
+func Init(cfg *to.Options, log *tl.Logger) (trace.Tracer, func(), error) {
 
 	if cfg == nil {
 		log.Info(

--- a/testdata/test.full.conf
+++ b/testdata/test.full.conf
@@ -105,6 +105,8 @@ tls_listen_address = 'test-tls'
     require_tls = true
     max_object_size_bytes = 999
     cache_key_prefix = 'test-prefix'
+    path_routing_disabled = false
+
         [origins.test.health_check_headers]
         'Authorization' = 'Basic SomeHash'
 


### PR DESCRIPTION
This PR adds full configuration reload capability, via an HTTP reload endpoint (listening on 127.0.0.1 by default) and via SIGHUP. Additionally, this PR adds a `-validate-config` CLI flag, which will validate the configuration and exit.  Example config and Kube deploy files are updated, however, Helm Charts will be published to the separate helm project and not in this project, as the helm directory will be removed in a separate PR.