### PR TITLE
Use RWMutex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.5.1
 	github.com/tinylib/msgp v1.1.1
-	github.com/tricksterproxy/mockster v1.1.0
+	github.com/tricksterproxy/mockster v1.1.1
 	github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036 // indirect
 	go.opentelemetry.io/otel v0.2.0
 	go.opentelemetry.io/otel/exporter/trace/jaeger v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/common v0.9.1
 	github.com/stretchr/testify v1.5.1
 	github.com/tinylib/msgp v1.1.1
-	github.com/tricksterproxy/mockster v0.0.0-20200228034438-cc033fc7cf65
+	github.com/tricksterproxy/mockster v1.1.0
 	github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036 // indirect
 	go.opentelemetry.io/otel v0.2.0
 	go.opentelemetry.io/otel/exporter/trace/jaeger v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiff
 github.com/tinylib/msgp v1.1.1 h1:TnCZ3FIuKeaIy+F45+Cnp+caqdXGy4z74HvwXN+570Y=
 github.com/tinylib/msgp v1.1.1/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tricksterproxy/mockster v0.0.0-20200228034438-cc033fc7cf65 h1:zLqePI530JVc8YS31aFT3fsfkl1Ze4lA2yqE/cU6x/0=
-github.com/tricksterproxy/mockster v0.0.0-20200228034438-cc033fc7cf65/go.mod h1:NEsMdXCHaMdn4G5gLWhUx5QZ2IxVFrHMBVuOnLpeTgw=
+github.com/tricksterproxy/mockster v1.1.0 h1:2QF7RmEscvJN1nRvtwgbI8UHQ+lRVVcEK+eyK+/cAWk=
+github.com/tricksterproxy/mockster v1.1.0/go.mod h1:FutC1axiYNHVo6h+LilamS49n0U8H0oQzSrX3MxikJA=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/timakin/bodyclose v0.0.0-20190930140734-f7f2e9bca95e/go.mod h1:Qimiff
 github.com/tinylib/msgp v1.1.1 h1:TnCZ3FIuKeaIy+F45+Cnp+caqdXGy4z74HvwXN+570Y=
 github.com/tinylib/msgp v1.1.1/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tricksterproxy/mockster v1.1.0 h1:2QF7RmEscvJN1nRvtwgbI8UHQ+lRVVcEK+eyK+/cAWk=
-github.com/tricksterproxy/mockster v1.1.0/go.mod h1:FutC1axiYNHVo6h+LilamS49n0U8H0oQzSrX3MxikJA=
+github.com/tricksterproxy/mockster v1.1.1 h1:emPI7q5OzL/a/IYpDVkQwfR3KqRbk4Q2yEsCDo2Od7w=
+github.com/tricksterproxy/mockster v1.1.1/go.mod h1:FutC1axiYNHVo6h+LilamS49n0U8H0oQzSrX3MxikJA=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ultraware/funlen v0.0.2/go.mod h1:Dp4UiAus7Wdb9KUZsYWZEWiRzGuM2kXM1lPbfaF6xhA=

--- a/pkg/cache/badger/badger.go
+++ b/pkg/cache/badger/badger.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache/metrics"
 	"github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	"github.com/tricksterproxy/trickster/pkg/util/log"
 
 	"github.com/dgraph-io/badger"
@@ -34,7 +35,17 @@ type Cache struct {
 	Name   string
 	Config *options.Options
 	Logger *log.Logger
-	dbh    *badger.DB
+	locker locks.NamedLocker
+
+	dbh *badger.DB
+}
+
+func (c *Cache) Locker() locks.NamedLocker {
+	return c.locker
+}
+
+func (c *Cache) SetLocker(l locks.NamedLocker) {
+	c.locker = l
 }
 
 // Configuration returns the Configuration for the Cache object

--- a/pkg/cache/badger/badger_test.go
+++ b/pkg/cache/badger/badger_test.go
@@ -25,6 +25,7 @@ import (
 	bo "github.com/tricksterproxy/trickster/pkg/cache/badger/options"
 	co "github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
@@ -271,5 +272,15 @@ func TestBadgerCache_Close(t *testing.T) {
 	// it should close
 	if err := bc.Close(); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestLocker(t *testing.T) {
+	cache := Cache{locker: locks.NewNamedLocker()}
+	l := cache.Locker()
+	cache.SetLocker(locks.NewNamedLocker())
+	m := cache.Locker()
+	if l == m {
+		t.Errorf("error setting locker")
 	}
 }

--- a/pkg/cache/bbolt/bbolt_test.go
+++ b/pkg/cache/bbolt/bbolt_test.go
@@ -177,6 +177,8 @@ func TestBboltCache_SetTTL(t *testing.T) {
 
 	bc.SetTTL(cacheKey, time.Duration(3600)*time.Second)
 
+	time.Sleep(time.Millisecond * 10)
+
 	exp2 := bc.Index.GetExpiration(cacheKey)
 	if exp2.IsZero() {
 		t.Errorf("expected time %d, got zero", int(time.Now().Unix())+3600)
@@ -505,6 +507,8 @@ func TestBboltCache_Retrieve(t *testing.T) {
 
 	// expire the object
 	bc.SetTTL(cacheKey, -1*time.Hour)
+
+	time.Sleep(time.Millisecond * 10)
 
 	// this should now return error
 	data, ls, err = bc.Retrieve(cacheKey, false)

--- a/pkg/cache/bbolt/bbolt_test.go
+++ b/pkg/cache/bbolt/bbolt_test.go
@@ -27,6 +27,7 @@ import (
 	io "github.com/tricksterproxy/trickster/pkg/cache/index/options"
 	co "github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
@@ -42,8 +43,12 @@ func newCacheConfig() co.Options {
 func storeBenchmark(b *testing.B) Cache {
 	testDbPath := "/tmp/test.db"
 	os.Remove(testDbPath)
-	cacheConfig := co.Options{CacheType: cacheType, BBolt: &bo.Options{Filename: testDbPath, Bucket: "trickster_test"}, Index: &io.Options{ReapInterval: time.Second}}
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	cacheConfig := co.Options{
+		CacheType: cacheType,
+		BBolt:     &bo.Options{Filename: testDbPath, Bucket: "trickster_test"},
+		Index:     &io.Options{ReapInterval: time.Second},
+	}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -63,7 +68,7 @@ func storeBenchmark(b *testing.B) Cache {
 
 func TestConfiguration(t *testing.T) {
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	cfg := bc.Configuration()
 	if cfg.CacheType != cacheType {
 		t.Errorf("expected %s got %s", cacheType, cfg.CacheType)
@@ -73,7 +78,7 @@ func TestConfiguration(t *testing.T) {
 func TestBboltCache_Connect(t *testing.T) {
 	cacheConfig := newCacheConfig()
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	// it should connect
 	err := bc.Connect()
 	if err != nil {
@@ -86,7 +91,7 @@ func TestBboltCache_ConnectFailed(t *testing.T) {
 	const expected = `open /root/noaccess.bbolt:`
 	cacheConfig := newCacheConfig()
 	cacheConfig.BBolt.Filename = "/root/noaccess.bbolt"
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	// it should connect
 	err := bc.Connect()
 	if err == nil {
@@ -104,7 +109,7 @@ func TestBboltCache_ConnectBadBucketName(t *testing.T) {
 	cacheConfig := newCacheConfig()
 	cacheConfig.BBolt.Bucket = ""
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	// it should connect
 	err := bc.Connect()
 	if err == nil {
@@ -119,7 +124,7 @@ func TestBboltCache_ConnectBadBucketName(t *testing.T) {
 func TestBboltCache_Store(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -143,7 +148,7 @@ func BenchmarkCache_Store(b *testing.B) {
 func TestBboltCache_SetTTL(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -221,7 +226,7 @@ func TestBboltCache_StoreNoIndex(t *testing.T) {
 	const expected = `value for key [] not in cache`
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 
 	err := bc.Connect()
 	if err != nil {
@@ -306,7 +311,7 @@ func BenchmarkCache_StoreNoIndex(b *testing.B) {
 func TestBboltCache_Remove(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -386,7 +391,7 @@ func BenchmarkCache_Remove(b *testing.B) {
 func TestBboltCache_BulkRemove(t *testing.T) {
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -451,10 +456,10 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 func TestBboltCache_Retrieve(t *testing.T) {
 
 	const expected1 = `value for key [cacheKey] not in cache`
-	const expected2 = `value for key [cacheKey] could not be deserialized from cache`
+	const expected2 = `value for key [cacheKey-invalid] could not be deserialized from cache`
 
 	cacheConfig := newCacheConfig()
-	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	bc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: locks.NewNamedLocker()}
 	defer os.RemoveAll(cacheConfig.BBolt.Filename)
 
 	err := bc.Connect()
@@ -518,16 +523,12 @@ func TestBboltCache_Retrieve(t *testing.T) {
 	}
 
 	// create a corrupted cache entry and expect an error
-	writeToBBolt(bc.dbh, cacheConfig.BBolt.Bucket, cacheKey, []byte("asdasdfasf"))
+	writeToBBolt(bc.dbh, cacheConfig.BBolt.Bucket, cacheKey+"-invalid", []byte("asdasdfasf"))
 
 	// it should fail to retrieve a value
-	data, ls, err = bc.Retrieve(cacheKey, false)
-	if err == nil {
-		t.Errorf("expected error for %s", expected2)
-		bc.Close()
-	}
-	if err.Error() != expected2 {
-		t.Errorf("expected error '%s' got '%s'", expected2, err.Error())
+	data, ls, err = bc.Retrieve(cacheKey+"-invalid", false)
+	if err == nil || err.Error() != expected2 {
+		t.Errorf("expected error '%s' got '%s'", expected2, err)
 	}
 	if string(data) != "" {
 		t.Errorf("wanted \"%s\". got \"%s\".", "data", data)
@@ -593,5 +594,15 @@ func BenchmarkCache_Retrieve(b *testing.B) {
 		if ls != status.LookupStatusKeyMiss {
 			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
 		}
+	}
+}
+
+func TestLocker(t *testing.T) {
+	cache := Cache{locker: locks.NewNamedLocker()}
+	l := cache.Locker()
+	cache.SetLocker(locks.NewNamedLocker())
+	m := cache.Locker()
+	if l == m {
+		t.Errorf("error setting locker")
 	}
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 )
 
 // ErrKNF represents the error "key not found in cache"
@@ -40,6 +41,8 @@ type Cache interface {
 	BulkRemove(cacheKeys []string)
 	Close() error
 	Configuration() *options.Options
+	Locker() locks.NamedLocker
+	SetLocker(locks.NamedLocker)
 }
 
 // MemoryCache is the interface for an in-memory cache
@@ -55,6 +58,8 @@ type MemoryCache interface {
 	Configuration() *options.Options
 	StoreReference(cacheKey string, data ReferenceObject, ttl time.Duration) error
 	RetrieveReference(cacheKey string, allowExpired bool) (interface{}, status.LookupStatus, error)
+	Locker() locks.NamedLocker
+	SetLocker(locks.NamedLocker)
 }
 
 // ReferenceObject defines an interface for a cache object possessing the ability to report

--- a/pkg/cache/filesystem/filesystem_test.go
+++ b/pkg/cache/filesystem/filesystem_test.go
@@ -268,6 +268,8 @@ func TestFilesystemCache_SetTTL(t *testing.T) {
 
 	fc.SetTTL(cacheKey, time.Duration(3600)*time.Second)
 
+	time.Sleep(time.Millisecond * 10)
+
 	exp2 := fc.Index.GetExpiration(cacheKey)
 	if exp2.IsZero() {
 		t.Errorf("expected time %d, got zero", int(time.Now().Unix())+3600)

--- a/pkg/cache/filesystem/filesystem_test.go
+++ b/pkg/cache/filesystem/filesystem_test.go
@@ -366,6 +366,9 @@ func TestFilesystemCache_Retrieve(t *testing.T) {
 	// expire the object
 	fc.SetTTL(cacheKey, -1*time.Hour)
 
+	// add sleep to let TTL be set in a separate goroutine
+	time.Sleep(time.Millisecond * 10)
+
 	// this should now return error
 	data, ls, err = fc.Retrieve(cacheKey, false)
 	if err == nil {

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -96,7 +96,7 @@ func (c *Cache) store(cacheKey string, byteData []byte, refData cache.ReferenceO
 		go c.Logger.Debug("memorycache cache store", tl.Pairs{"cacheKey": cacheKey, "length": l, "ttl": ttl, "is_direct": isDirect})
 		c.client.Store(cacheKey, o1)
 		if updateIndex {
-			go c.Index.UpdateObject(o2)
+			c.Index.UpdateObject(o2)
 		}
 		nl.Release()
 	}

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -25,6 +25,7 @@ import (
 	io "github.com/tricksterproxy/trickster/pkg/cache/index/options"
 	co "github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
@@ -34,13 +35,15 @@ const cacheKey = "cacheKey"
 type testReferenceObject struct {
 }
 
+var testLocker = locks.NewNamedLocker()
+
 func (r *testReferenceObject) Size() int {
 	return 1
 }
 
 func storeBenchmark(b *testing.B) Cache {
 	cacheConfig := co.Options{CacheType: cacheType, Index: &io.Options{ReapInterval: 0}}
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -88,7 +91,7 @@ func TestCache_Connect(t *testing.T) {
 func TestCache_StoreReferenceDirect(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -111,7 +114,7 @@ func TestCache_StoreReferenceDirect(t *testing.T) {
 
 func TestCache_StoreReference(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -126,7 +129,7 @@ func TestCache_StoreReference(t *testing.T) {
 
 func TestCache_Store(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -148,7 +151,7 @@ func TestCache_Retrieve(t *testing.T) {
 	const expected1 = `value for key [cacheKey] not in cache`
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -241,7 +244,7 @@ func TestCache_Close(t *testing.T) {
 
 func TestCache_Remove(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -319,7 +322,7 @@ func BenchmarkCache_Remove(b *testing.B) {
 
 func TestCache_BulkRemove(t *testing.T) {
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -383,7 +386,7 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 func TestMemoryCache_SetTTL(t *testing.T) {
 
 	cacheConfig := newCacheConfig(t)
-	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error")}
+	mc := Cache{Config: &cacheConfig, Logger: tl.ConsoleLogger("error"), locker: testLocker}
 
 	err := mc.Connect()
 	if err != nil {
@@ -453,5 +456,15 @@ func BenchmarkCache_SetTTL(b *testing.B) {
 		if diff < expected {
 			b.Errorf("expected diff >= %d, got %d from: %d - %d", expected, diff, e2, e1)
 		}
+	}
+}
+
+func TestLocker(t *testing.T) {
+	cache := Cache{locker: locks.NewNamedLocker()}
+	l := cache.Locker()
+	cache.SetLocker(locks.NewNamedLocker())
+	m := cache.Locker()
+	if l == m {
+		t.Errorf("error setting locker")
 	}
 }

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -163,6 +163,8 @@ func TestCache_Retrieve(t *testing.T) {
 		t.Error(err)
 	}
 
+	time.Sleep(time.Millisecond * 10)
+
 	// it should retrieve a value
 	var data []byte
 	var ls status.LookupStatus
@@ -179,6 +181,8 @@ func TestCache_Retrieve(t *testing.T) {
 
 	// expire the object
 	mc.SetTTL(cacheKey, -1*time.Hour)
+
+	time.Sleep(time.Millisecond * 10)
 
 	// this should now return error
 	data, ls, err = mc.Retrieve(cacheKey, false)
@@ -405,6 +409,8 @@ func TestMemoryCache_SetTTL(t *testing.T) {
 		t.Error(err)
 	}
 
+	time.Sleep(time.Millisecond * 10)
+
 	exp1 = mc.Index.GetExpiration(cacheKey)
 	if exp1.IsZero() {
 		t.Errorf("expected time %d, got zero", int(time.Now().Unix())+60)
@@ -413,6 +419,8 @@ func TestMemoryCache_SetTTL(t *testing.T) {
 	e1 := int(exp1.Unix())
 
 	mc.SetTTL(cacheKey, time.Duration(3600)*time.Second)
+
+	time.Sleep(time.Millisecond * 10)
 
 	exp2 := mc.Index.GetExpiration(cacheKey)
 	if exp2.IsZero() {

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache/metrics"
 	"github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
@@ -38,9 +39,18 @@ type Cache struct {
 	Name   string
 	Config *options.Options
 	Logger *tl.Logger
+	locker locks.NamedLocker
 
 	client redis.Cmdable
 	closer func() error
+}
+
+func (c *Cache) Locker() locks.NamedLocker {
+	return c.locker
+}
+
+func (c *Cache) SetLocker(l locks.NamedLocker) {
+	c.locker = l
 }
 
 // Configuration returns the Configuration for the Cache object

--- a/pkg/cache/redis/redis_test.go
+++ b/pkg/cache/redis/redis_test.go
@@ -25,6 +25,7 @@ import (
 	ro "github.com/tricksterproxy/trickster/pkg/cache/redis/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
 	"github.com/tricksterproxy/trickster/pkg/config"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 
 	"github.com/alicebob/miniredis"
@@ -513,5 +514,15 @@ func BenchmarkCache_BulkRemove(b *testing.B) {
 		if ls != status.LookupStatusKeyMiss {
 			b.Errorf("expected %s got %s", status.LookupStatusKeyMiss, ls)
 		}
+	}
+}
+
+func TestLocker(t *testing.T) {
+	cache := Cache{locker: locks.NewNamedLocker()}
+	l := cache.Locker()
+	cache.SetLocker(locks.NewNamedLocker())
+	m := cache.Locker()
+	if l == m {
+		t.Errorf("error setting locker")
 	}
 }

--- a/pkg/cache/registration/registration.go
+++ b/pkg/cache/registration/registration.go
@@ -27,6 +27,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/redis"
 	"github.com/tricksterproxy/trickster/pkg/config"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/util/log"
 )
 
@@ -88,6 +89,7 @@ func NewCache(cacheName string, cfg *options.Options, logger *tl.Logger) cache.C
 		c = &memory.Cache{Name: cacheName, Config: cfg, Logger: logger}
 	}
 
+	c.SetLocker(locks.NewNamedLocker())
 	c.Connect()
 	return c
 }

--- a/pkg/locks/locks.go
+++ b/pkg/locks/locks.go
@@ -64,6 +64,7 @@ type namedLock struct {
 	locker         *namedLocker
 }
 
+// Release releases the write lock on the subject Named Lock
 func (nl *namedLock) Release() error {
 
 	if nl.name == "" {
@@ -81,6 +82,7 @@ func (nl *namedLock) Release() error {
 	return nil
 }
 
+// RRelease releases the read lock on the subject Named Lock
 func (nl *namedLock) RRelease() error {
 
 	if nl.name == "" {
@@ -105,7 +107,7 @@ func (nl *namedLock) WriteLockCounter() int {
 	return nl.writeLockCount
 }
 
-// Acquire locks the named lock, and blocks until the lock is acquired
+// Acquire locks the named lock for writing, and blocks until the wlock is acquired
 func (lk *namedLocker) Acquire(lockName string) (NamedLock, error) {
 	if lockName == "" {
 		return nil, fmt.Errorf("invalid lock name: %s", lockName)

--- a/pkg/locks/locks.go
+++ b/pkg/locks/locks.go
@@ -21,18 +21,18 @@ import (
 )
 
 var locks = make(map[string]*namedLock)
-var mapLock = sync.Mutex{}
+var mapLock = &sync.Mutex{}
 
 type namedLock struct {
-	*sync.Mutex
+	*sync.RWMutex
 	name      string
 	queueSize int
 }
 
 func newNamedLock(name string) *namedLock {
 	return &namedLock{
-		name:  name,
-		Mutex: &sync.Mutex{},
+		name:    name,
+		RWMutex: &sync.RWMutex{},
 	}
 }
 

--- a/pkg/locks/locks.go
+++ b/pkg/locks/locks.go
@@ -21,6 +21,7 @@ import (
 	"sync/atomic"
 )
 
+// NamedLocker provides a locker for handling Named Locks
 type NamedLocker interface {
 	Acquire(string) (NamedLock, error)
 	RAcquire(string) (NamedLock, error)
@@ -31,6 +32,7 @@ type namedLocker struct {
 	mapLock *sync.Mutex
 }
 
+// NewNamedLocker returns a new Named Locker
 func NewNamedLocker() NamedLocker {
 	return &namedLocker{
 		locks:   make(map[string]*namedLock),
@@ -38,6 +40,7 @@ func NewNamedLocker() NamedLocker {
 	}
 }
 
+// NamedLock defines the interface for implementing Named Locks
 type NamedLock interface {
 	Release() error
 	RRelease() error
@@ -57,10 +60,8 @@ type namedLock struct {
 	name           string
 	queueSize      int32
 	writeLockCount int
-	// hasWriteLock   bool
-	// hasReadLock    bool
-	releaser func()
-	locker   *namedLocker
+	releaser       func()
+	locker         *namedLocker
 }
 
 func (nl *namedLock) Release() error {
@@ -97,6 +98,9 @@ func (nl *namedLock) RRelease() error {
 	return nil
 }
 
+// WriteLockCounter returns the number of write locks acquired by the namedLock
+// This function should only be called by a goroutine actively holding a write lock,
+// as it is otherwise not atomic
 func (nl *namedLock) WriteLockCounter() int {
 	return nl.writeLockCount
 }

--- a/pkg/locks/locks_test.go
+++ b/pkg/locks/locks_test.go
@@ -162,3 +162,29 @@ func TestWriteLockCounter(t *testing.T) {
 	}
 
 }
+
+func TestWriteLockMode(t *testing.T) {
+
+	nl := newNamedLock("testKey", nil)
+	if nl.WriteLockMode() {
+		t.Error("expected false")
+	}
+	nl.writeLockMode = 1
+	if !nl.WriteLockMode() {
+		t.Error("expected true")
+	}
+
+}
+
+func TestUpgrade(t *testing.T) {
+
+	locker := NewNamedLocker()
+	nl, _ := locker.RAcquire("test")
+	if nl.WriteLockCounter() != 0 {
+		t.Errorf("expected 0 got %d", nl.WriteLockCounter())
+	}
+	nl, _ = nl.Upgrade()
+	if nl.WriteLockCounter() != 1 {
+		t.Errorf("expected 1 got %d", nl.WriteLockCounter())
+	}
+}

--- a/pkg/locks/locks_test.go
+++ b/pkg/locks/locks_test.go
@@ -50,14 +50,15 @@ func TestLocks(t *testing.T) {
 		t.Errorf("expected 11 got %d", testVal)
 	}
 
-	expected := "not currently locked: test"
-	err := nl.Release()
+	expected := "invalid lock name: "
+	_, err := lk.Acquire("")
 	if err.Error() != expected {
 		t.Errorf("got %s expected %s", err.Error(), expected)
 	}
 
-	expected = "invalid lock name: "
-	_, err = lk.Acquire("")
+	nl3, _ := lk.Acquire("test1")
+	nl3.(*namedLock).name = ""
+	err = nl3.RRelease()
 	if err.Error() != expected {
 		t.Errorf("got %s expected %s", err.Error(), expected)
 	}
@@ -123,7 +124,7 @@ func TestLockReadAndWrite(t *testing.T) {
 	go func() {
 		nl1, _ := lk.RAcquire("test")
 		j = i
-		nl1.Release()
+		nl1.RRelease()
 		wg.Done()
 	}()
 

--- a/pkg/proxy/engines/cache_test.go
+++ b/pkg/proxy/engines/cache_test.go
@@ -33,6 +33,7 @@ import (
 	cr "github.com/tricksterproxy/trickster/pkg/cache/registration"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
 	"github.com/tricksterproxy/trickster/pkg/config"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tc "github.com/tricksterproxy/trickster/pkg/proxy/context"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 	"github.com/tricksterproxy/trickster/pkg/proxy/ranges/byterange"
@@ -440,6 +441,7 @@ func TestQueryCache(t *testing.T) {
 // Mock Cache for testing error conditions
 type testCache struct {
 	configuration *co.Options
+	locker        locks.NamedLocker
 }
 
 func (tc *testCache) Connect() error {
@@ -461,3 +463,5 @@ func (tc *testCache) Remove(cacheKey string)                    {}
 func (tc *testCache) BulkRemove(cacheKeys []string)             {}
 func (tc *testCache) Close() error                              { return errTest }
 func (tc *testCache) Configuration() *co.Options                { return tc.configuration }
+func (tc *testCache) Locker() locks.NamedLocker                 { return tc.locker }
+func (tc *testCache) SetLocker(l locks.NamedLocker)             { tc.locker = l }

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -391,6 +391,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 
 	if isLocked {
 		nl.Release()
+		isLocked = false
 	}
 
 	// Respond to the user. Using the response headers from a Delta Response,

--- a/pkg/proxy/engines/deltaproxycache_test.go
+++ b/pkg/proxy/engines/deltaproxycache_test.go
@@ -120,6 +120,9 @@ func TestDeltaProxyCacheRequestMissThenHit(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Give time for the object to be written to cache in a separate goroutine from response
+	time.Sleep(time.Millisecond * 10)
+
 	// get cache hit coverage too by repeating:
 
 	w = httptest.NewRecorder()
@@ -730,6 +733,9 @@ func TestDeltaProxyCacheRequestRangeMiss(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Give time for the object to be written to cache in a separate goroutine from response
+	time.Sleep(time.Millisecond * 10)
+
 	// Test Range Miss Low End
 
 	extr.Start = extr.Start.Add(time.Duration(-3) * time.Hour)
@@ -901,6 +907,9 @@ func TestDeltaProxyCacheRequestFastForward(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// Give time for the object to be written to cache in a separate goroutine from response
+	time.Sleep(time.Millisecond * 10)
 
 	// do it again and look for a cache hit on the timeseries and fast forward
 
@@ -1172,6 +1181,9 @@ func TestDeltaProxyCacheRequestWithUnmarshalAndUpstreamErrors(t *testing.T) {
 		t.Error(err)
 	}
 
+	// Give time for the object to be written to cache in a separate goroutine from response
+	time.Sleep(time.Millisecond * 10)
+
 	key := oc.Host + ".61a603af5b94ea305dc3fa35af4eed98"
 
 	_, _, err = client.cache.Retrieve(key, false)
@@ -1199,6 +1211,9 @@ func TestDeltaProxyCacheRequestWithUnmarshalAndUpstreamErrors(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// Give time for the object to be written to cache in a separate goroutine from response
+	time.Sleep(time.Millisecond * 10)
 
 	u.RawQuery = fmt.Sprintf("step=%d&start=%d&end=%d&query=%s", int(step.Seconds()), extr.Start.Unix(), extr.End.Unix(), queryReturnsBadRequest)
 	client.cache.Store(key, []byte("foo"), time.Duration(30)*time.Second)
@@ -1478,6 +1493,9 @@ func TestDeltaProxyCacheRequest_BackfillTolerance(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// Give time for the object to be written to cache in a separate goroutine from response
+	time.Sleep(time.Millisecond * 10)
 
 	// get cache partial hit coverage too by repeating:
 	w = httptest.NewRecorder()

--- a/pkg/proxy/engines/deltaproxycache_test.go
+++ b/pkg/proxy/engines/deltaproxycache_test.go
@@ -1184,7 +1184,7 @@ func TestDeltaProxyCacheRequestWithUnmarshalAndUpstreamErrors(t *testing.T) {
 	// Give time for the object to be written to cache in a separate goroutine from response
 	time.Sleep(time.Millisecond * 10)
 
-	key := oc.Host + ".61a603af5b94ea305dc3fa35af4eed98"
+	key := oc.Host + ".dpc.61a603af5b94ea305dc3fa35af4eed98"
 
 	_, _, err = client.cache.Retrieve(key, false)
 	if err != nil {

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 
 	txe "github.com/tricksterproxy/trickster/pkg/proxy/errors"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
@@ -52,6 +53,7 @@ type HTTPDocument struct {
 	isFulfillment    bool
 	isLoaded         bool
 	timeseries       timeseries.Timeseries
+	headerLock       *sync.Mutex
 }
 
 // Size returns the size of the HTTPDocument's headers, CachingPolicy, RangeParts, Body and timeseries data

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -211,7 +211,9 @@ func handleTrueCacheHit(pr *proxyRequest) error {
 		pr.cacheStatus = status.LookupStatusNegativeCacheHit
 	}
 
-	pr.upstreamResponse = &http.Response{StatusCode: d.StatusCode, Request: pr.Request, Header: d.Headers}
+	d.headerLock.Lock()
+	pr.upstreamResponse = &http.Response{StatusCode: d.StatusCode, Request: pr.Request, Header: http.Header(d.Headers).Clone()}
+	d.headerLock.Unlock()
 	if pr.wantsRanges {
 		h, b := d.RangeParts.ExtractResponseRange(pr.wantedRanges, d.ContentLength, d.ContentType, d.Body)
 		headers.Merge(pr.upstreamResponse.Header, h)

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -45,6 +45,10 @@ func handleCacheKeyHit(pr *proxyRequest) error {
 
 	ok, err := confirmTrueCacheHit(pr)
 	if ok {
+		if pr.hasReadLock {
+			pr.cacheLock.RRelease()
+			pr.hasReadLock = false
+		}
 		return handleTrueCacheHit(pr)
 	}
 
@@ -63,6 +67,12 @@ func handleCachePartialHit(pr *proxyRequest) error {
 			// request to the correct handle; we just return its result here.
 			return err
 		}
+	}
+
+	b1, b2 := upgradeLock(pr)
+	if b1 && !b2 {
+		rerunRequest(pr)
+		return nil
 	}
 
 	pr.prepareUpstreamRequests()
@@ -136,6 +146,12 @@ func handleCacheRangeMiss(pr *proxyRequest) error {
 }
 
 func handleCacheRevalidation(pr *proxyRequest) error {
+
+	b1, b2 := upgradeLock(pr)
+	if b1 && !b2 {
+		rerunRequest(pr)
+		return nil
+	}
 
 	rsc := request.GetResources(pr.Request)
 	oc := rsc.OriginConfig
@@ -228,6 +244,12 @@ func handleTrueCacheHit(pr *proxyRequest) error {
 
 func handleCacheKeyMiss(pr *proxyRequest) error {
 
+	b1, b2 := upgradeLock(pr)
+	if b1 && !b2 {
+		rerunRequest(pr)
+		return nil
+	}
+
 	rsc := request.GetResources(pr.Request)
 	pc := rsc.PathConfig
 	oc := rsc.OriginConfig
@@ -238,6 +260,7 @@ func handleCacheKeyMiss(pr *proxyRequest) error {
 		// a PCF session is in progress for this URL, join this client to it.
 		if pcfExists {
 			pr.cacheLock.Release()
+			pr.hasWriteLock = false
 			pcf := pcfResult.(ProgressiveCollapseForwarder)
 			pr.upstreamResponse = pcf.GetResp()
 			pr.responseWriter = PrepareResponseWriter(pr.responseWriter, pr.upstreamResponse.StatusCode,
@@ -306,12 +329,16 @@ func handleResponse(pr *proxyRequest) error {
 	return nil
 }
 
-// Cache Status Response Handler Mappings
-var cacheResponseHandlers = map[status.LookupStatus]func(*proxyRequest) error{
-	status.LookupStatusHit:        handleCacheKeyHit,
-	status.LookupStatusPartialHit: handleCachePartialHit,
-	status.LookupStatusKeyMiss:    handleCacheKeyMiss,
-	status.LookupStatusRangeMiss:  handleCacheRangeMiss,
+var cacheResponseHandlers map[status.LookupStatus]func(*proxyRequest) error
+
+func init() {
+	// Cache Status Response Handler Mappings
+	cacheResponseHandlers = map[status.LookupStatus]func(*proxyRequest) error{
+		status.LookupStatusHit:        handleCacheKeyHit,
+		status.LookupStatusPartialHit: handleCachePartialHit,
+		status.LookupStatusKeyMiss:    handleCacheKeyMiss,
+		status.LookupStatusRangeMiss:  handleCacheRangeMiss,
+	}
 }
 
 func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, status.LookupStatus) {
@@ -325,7 +352,7 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 
 	pr.cachingPolicy = GetRequestCachingPolicy(pr.Header)
 
-	pr.key = oc.CacheKeyPrefix + "." + pr.DeriveCacheKey(nil, "")
+	pr.key = oc.CacheKeyPrefix + ".opc." + pr.DeriveCacheKey(nil, "")
 
 	// if a PCF entry exists, or the client requested no-cache for this object, proxy out to it
 	pcfResult, pcfExists := Reqs.Load(pr.key)
@@ -346,7 +373,8 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 	pr.cachingPolicy.ParseClientConditionals()
 
 	if !rsc.NoLock {
-		pr.cacheLock, _ = cc.Locker().Acquire(pr.key)
+		pr.cacheLock, _ = cc.Locker().RAcquire(pr.key)
+		pr.hasReadLock = true
 	}
 
 	var err error
@@ -365,14 +393,20 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 		handleCacheKeyMiss(pr)
 	}
 
-	if !rsc.NoLock {
+	if pr.hasWriteLock {
 		pr.cacheLock.Release()
+	} else if pr.hasReadLock {
+		pr.cacheLock.RRelease()
+	}
+
+	if pr.wasReran {
+		return nil, status.LookupStatusRevalidated
 	}
 
 	// newProxyRequest sets pr.started to time.Now()
 	pr.elapsed = time.Since(pr.started)
 	el := float64(pr.elapsed.Milliseconds()) / 1000.0
-	recordOPCResult(r, pr.cacheStatus, pr.upstreamResponse.StatusCode, r.URL.Path, el, pr.upstreamResponse.Header)
+	recordOPCResult(pr, pr.cacheStatus, pr.upstreamResponse.StatusCode, r.URL.Path, el, pr.upstreamResponse.Header)
 
 	return pr.upstreamResponse, pr.cacheStatus
 }
@@ -395,6 +429,33 @@ func FetchViaObjectProxyCache(r *http.Request) ([]byte, *http.Response, bool) {
 	return w.Bytes(), resp, cacheStatus == status.LookupStatusHit
 }
 
-func recordOPCResult(r *http.Request, cacheStatus status.LookupStatus, httpStatus int, path string, elapsed float64, header http.Header) {
-	recordResults(r, "ObjectProxyCache", cacheStatus, httpStatus, path, "", elapsed, nil, header)
+func recordOPCResult(pr *proxyRequest, cacheStatus status.LookupStatus, httpStatus int, path string, elapsed float64, header http.Header) {
+	pr.mapLock.Lock()
+	recordResults(pr.Request, "ObjectProxyCache", cacheStatus, httpStatus, path, "", elapsed, nil, header)
+	pr.mapLock.Unlock()
+}
+
+func upgradeLock(pr *proxyRequest) (bool, bool) {
+	if pr.hasReadLock && !pr.hasWriteLock {
+		cwc := pr.cacheLock.WriteLockCounter()
+		pr.cacheLock.Upgrade()
+		pr.hasReadLock = false
+		pr.hasWriteLock = true
+		if pr.cacheLock.WriteLockCounter()-cwc != 1 {
+			return true, false
+		}
+		return true, true
+	}
+	return false, false
+}
+
+func rerunRequest(pr *proxyRequest) {
+	pr.wasReran = true
+	if w, ok := pr.responseWriter.(http.ResponseWriter); ok {
+		if pr.hasWriteLock {
+			pr.cacheLock.Release()
+			pr.hasWriteLock = false
+		}
+		ObjectProxyCacheRequest(w, pr.Request)
+	}
 }

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -19,7 +19,6 @@ package engines
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -318,8 +317,6 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 	rsc := request.GetResources(r)
 	oc := rsc.OriginConfig
 	cc := rsc.CacheClient
-
-	fmt.Println("!!!!!!!!", cc.Locker())
 
 	pr := newProxyRequest(r, w)
 	pr.parseRequestRanges()

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/tricksterproxy/mockster/pkg/mocks/byterange"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tc "github.com/tricksterproxy/trickster/pkg/proxy/context"
 	"github.com/tricksterproxy/trickster/pkg/proxy/forwarding"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
@@ -1184,7 +1185,7 @@ func TestFetchViaObjectProxyCacheRequestErroringCache(t *testing.T) {
 	}
 	defer ts.Close()
 
-	tc := &testCache{configuration: rsc.CacheConfig}
+	tc := &testCache{configuration: rsc.CacheConfig, locker: locks.NewNamedLocker()}
 	rsc.CacheClient = tc
 	tc.configuration.CacheType = "test"
 

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -149,6 +149,7 @@ func TestObjectProxyCacheRequest(t *testing.T) {
 }
 
 func TestObjectProxyCachePartialHit(t *testing.T) {
+
 	ts, _, r, rsc, err := setupTestHarnessOPCRange(nil)
 	if err != nil {
 		t.Error(err)
@@ -161,6 +162,7 @@ func TestObjectProxyCachePartialHit(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
 	_, e := testFetchOPC(r, http.StatusPartialContent, expectedBody, map[string]string{"status": "kmiss"})
 	for _, err = range e {
 		t.Error(err)
@@ -348,7 +350,7 @@ func TestFullArticuation(t *testing.T) {
 		t.Error(err)
 	}
 
-	r.Header.Set(headers.NameRange, "bytes=0-1221")
+	r.Header.Set(headers.NameRange, "bytes=0-1223")
 	r.URL.Path = "/byterange/new/test/path/22"
 	r.URL.RawQuery = ""
 	expectedBody, err = getExpectedRangeBody(r, "722af19813169c99d8bda37a2f244f39")
@@ -360,8 +362,8 @@ func TestFullArticuation(t *testing.T) {
 		t.Error(err)
 	}
 
-	r.Header.Set(headers.NameRange, "bytes=0-1220,1221-1221")
-	expectedBody, err = getExpectedRangeBody(r, "0a6d16343fbe859a10cf1ac673e23dc9")
+	r.Header.Set(headers.NameRange, "bytes=0-1220,1221-1223")
+	expectedBody, err = getExpectedRangeBody(r, "f8813b96e6b06ea1d826bb921690f87b")
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
+	"github.com/tricksterproxy/trickster/pkg/locks"
 	tctx "github.com/tricksterproxy/trickster/pkg/proxy/context"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 	"github.com/tricksterproxy/trickster/pkg/proxy/ranges/byterange"
@@ -53,6 +54,7 @@ type proxyRequest struct {
 
 	cacheDocument *HTTPDocument
 	cacheBuffer   *bytes.Buffer
+	cacheLock     locks.NamedLock
 
 	key          string
 	started      time.Time

--- a/pkg/proxy/engines/proxy_request_test.go
+++ b/pkg/proxy/engines/proxy_request_test.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -91,6 +92,7 @@ func TestSetBodyWriter(t *testing.T) {
 		responseWriter:   bytes.NewBuffer(buff),
 		upstreamResponse: &http.Response{StatusCode: http.StatusOK},
 		cachingPolicy:    &CachingPolicy{},
+		mapLock:          &sync.Mutex{},
 	}
 
 	PrepareResponseWriter(pr.responseWriter, pr.upstreamResponse.StatusCode, pr.upstreamResponse.Header)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,7 @@ github.com/stretchr/testify/assert
 # github.com/tinylib/msgp v1.1.1
 ## explicit
 github.com/tinylib/msgp/msgp
-# github.com/tricksterproxy/mockster v1.1.0
+# github.com/tricksterproxy/mockster v1.1.1
 ## explicit
 github.com/tricksterproxy/mockster/pkg/mocks/byterange
 github.com/tricksterproxy/mockster/pkg/mocks/prometheus

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -108,7 +108,7 @@ github.com/stretchr/testify/assert
 # github.com/tinylib/msgp v1.1.1
 ## explicit
 github.com/tinylib/msgp/msgp
-# github.com/tricksterproxy/mockster v0.0.0-20200228034438-cc033fc7cf65
+# github.com/tricksterproxy/mockster v1.1.0
 ## explicit
 github.com/tricksterproxy/mockster/pkg/mocks/byterange
 github.com/tricksterproxy/mockster/pkg/mocks/prometheus


### PR DESCRIPTION
This PR will updates the Named Locks packages to eliminate package-level access and anonymous locking/unlocking, while adding an exportable Locker, RWMutex support, and an Upgrade function to morph a read lock into a write lock, while maintaining continuity. RWMutex implementation is added to the Delta Proxy Cache and Object Proxy Cache.