### PR TITLE
add per-query fast-forward-disable ability (prom)

### DIFF
--- a/pkg/proxy/origins/prometheus/prometheus.go
+++ b/pkg/proxy/origins/prometheus/prometheus.go
@@ -193,5 +193,9 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 		trq.FastForwardDisable = true
 	}
 
+	if strings.Contains(trq.Statement, timeseries.FastForwardUserDisableFlag) {
+		trq.FastForwardDisable = true
+	}
+
 	return trq, nil
 }

--- a/pkg/timeseries/timeseries.go
+++ b/pkg/timeseries/timeseries.go
@@ -20,6 +20,10 @@ package timeseries
 
 import "time"
 
+// FastForwardUserDisableFlag is a string that is checked to determine if Fast Forward
+// should be selectively disabled for the provided query
+const FastForwardUserDisableFlag = "trickster-fast-forward:off"
+
 // Timeseries represents a Response Object from a Timeseries Database
 type Timeseries interface {
 	// SetExtents sets the Extents of the Timeseries


### PR DESCRIPTION
This patch will check if the provided prometheus query contains the string `trickster-fast-forward:off` and, if so, will disable the fast forward feature for the query. If Fast Forward is disabled at the origin level, including this string in the query will be ineffectual. Likewise, this patch provides no ability to enable fast forward for queries when it is disabled at the origin level.

Safe usage is to add a comment to the end of a PromQL query as follows:
```
go_goroutines{job="trickster"} # trickster-fast-forward:off
```
