### PR TITLE
update windows default paths

### DIFF
--- a/pkg/config/defaults/defaults_windows.go
+++ b/pkg/config/defaults/defaults_windows.go
@@ -20,7 +20,7 @@ package defaults
 
 const (
 	// DefaultCachePath is the default Cache Path for the Filesystem Cache
-	DefaultCachePath = `%TEMP%\trickster`
+	DefaultCachePath = `.\cache`
 	// DefaultConfigPath defines the default location of the Trickster config file
-	DefaultConfigPath = `%APPDATA%\trickster\trickster.conf`
+	DefaultConfigPath = `.\trickster.conf`
 )


### PR DESCRIPTION
this patch updates the default paths to reside under `.` for Windows compilations.