### PR TITLE
additional header access thread safety

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -129,13 +129,13 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 		)
 		cacheStatus = status.LookupStatusPurge
 		go cache.Remove(key)
-		// to-do, re-add log request bool
 		cts, doc, elapsed, err = fetchTimeseries(pr, trq, client)
 		if err != nil {
 			pr.cacheLock.RRelease()
+			h := doc.SafeHeaderClone()
 			recordDPCResult(r, status.LookupStatusProxyError, doc.StatusCode,
-				r.URL.Path, "", elapsed.Seconds(), nil, doc.Headers)
-			Respond(w, doc.StatusCode, doc.Headers, doc.Body)
+				r.URL.Path, "", elapsed.Seconds(), nil, h)
+			Respond(w, doc.StatusCode, h, doc.Body)
 			return // fetchTimeseries logs the error
 		}
 	} else {
@@ -144,10 +144,10 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 			cts, doc, elapsed, err = fetchTimeseries(pr, trq, client)
 			if err != nil {
 				pr.cacheLock.RRelease()
+				h := doc.SafeHeaderClone()
 				recordDPCResult(r, status.LookupStatusProxyError, doc.StatusCode,
-					r.URL.Path, "", elapsed.Seconds(), nil, doc.Headers)
-
-				Respond(w, doc.StatusCode, doc.Headers, doc.Body)
+					r.URL.Path, "", elapsed.Seconds(), nil, h)
+				Respond(w, doc.StatusCode, h, doc.Body)
 				return // fetchTimeseries logs the error
 			}
 		} else {
@@ -168,9 +168,10 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 				cts, doc, elapsed, err = fetchTimeseries(pr, trq, client)
 				if err != nil {
 					pr.cacheLock.RRelease()
+					h := doc.SafeHeaderClone()
 					recordDPCResult(r, status.LookupStatusProxyError, doc.StatusCode,
-						r.URL.Path, "", elapsed.Seconds(), nil, doc.Headers)
-					Respond(w, doc.StatusCode, doc.Headers, doc.Body)
+						r.URL.Path, "", elapsed.Seconds(), nil, h)
+					Respond(w, doc.StatusCode, h, doc.Body)
 					return // fetchTimeseries logs the error
 				}
 			} else {
@@ -418,9 +419,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 	rts.SetExtents(nil) // so they are not included in the client response json
 	rts.SetStep(0)
 	rdata, err := client.MarshalTimeseries(rts)
-	doc.headerLock.Lock()
-	rh := http.Header(doc.Headers).Clone()
-	doc.headerLock.Unlock()
+	rh := doc.SafeHeaderClone()
 
 	switch cacheStatus {
 	case status.LookupStatusKeyMiss, status.LookupStatusPartialHit, status.LookupStatusRangeMiss:

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -56,6 +56,14 @@ type HTTPDocument struct {
 	headerLock       sync.Mutex
 }
 
+// SafeHeaderClone returns a threadsafe copy of the Document Header
+func (d *HTTPDocument) SafeHeaderClone() http.Header {
+	d.headerLock.Lock()
+	h := http.Header(d.Headers).Clone()
+	d.headerLock.Unlock()
+	return h
+}
+
 // Size returns the size of the HTTPDocument's headers, CachingPolicy, RangeParts, Body and timeseries data
 func (d *HTTPDocument) Size() int {
 	var i int
@@ -91,7 +99,9 @@ func (d *HTTPDocument) SetBody(body []byte) {
 	if d.Headers == nil {
 		d.Headers = make(http.Header)
 	}
+	d.headerLock.Lock()
 	http.Header(d.Headers).Set(headers.NameContentLength, strconv.Itoa(len(body)))
+	d.headerLock.Unlock()
 }
 
 // LoadRangeParts convert a StoredRangeParts into a RangeParts

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -228,10 +228,8 @@ func handleTrueCacheHit(pr *proxyRequest) error {
 		pr.cacheStatus = status.LookupStatusNegativeCacheHit
 	}
 
-	d.headerLock.Lock()
 	pr.upstreamResponse = &http.Response{StatusCode: d.StatusCode, Request: pr.Request,
-		Header: http.Header(d.Headers).Clone()}
-	d.headerLock.Unlock()
+		Header: d.SafeHeaderClone()}
 	if pr.wantsRanges {
 		h, b := d.RangeParts.ExtractResponseRange(pr.wantedRanges, d.ContentLength, d.ContentType, d.Body)
 		headers.Merge(pr.upstreamResponse.Header, h)


### PR DESCRIPTION
this PR addresses potential map contention panics during the shared use of headers of a cached object, when simultaneous cache hits are handled for that object.