### PR TITLE
better err logging when marshaling fails

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -443,6 +443,10 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 				} else {
 					cdata, err := client.MarshalTimeseries(cts)
 					if err != nil {
+						pr.Logger.Error("error marshaling timeseries", tl.Pairs{
+							"cacheKey": key,
+							"detail":   err.Error(),
+						})
 						return
 					}
 					doc.Body = cdata


### PR DESCRIPTION
this PR will properly log errors when a cache object fails to marshal or unmarshal