### PR TITLE
Add Cache to proxy Client interface. Enforce origins implement Client

### DIFF
--- a/pkg/proxy/origins/clickhouse/clickhouse.go
+++ b/pkg/proxy/origins/clickhouse/clickhouse.go
@@ -24,12 +24,15 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/proxy"
 	"github.com/tricksterproxy/trickster/pkg/proxy/errors"
+	"github.com/tricksterproxy/trickster/pkg/proxy/origins"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
 	tt "github.com/tricksterproxy/trickster/pkg/proxy/timeconv"
 	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
 	"github.com/tricksterproxy/trickster/pkg/util/regexp/matching"
 )
+
+var _ origins.Client = (*Client)(nil)
 
 // Client Implements the Proxy Client Interface
 type Client struct {
@@ -48,7 +51,7 @@ type Client struct {
 
 // NewClient returns a new Client Instance
 func NewClient(name string, oc *oo.Options, router http.Handler,
-	cache cache.Cache) (*Client, error) {
+	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
 	return &Client{name: name, config: oc, router: router, cache: cache,

--- a/pkg/proxy/origins/client.go
+++ b/pkg/proxy/origins/client.go
@@ -40,4 +40,6 @@ type Client interface {
 	SetCache(cache.Cache)
 	// Router returns a Router that handles HTTP Requests for this client
 	Router() http.Handler
+	// Cache returns a handle to the Cache instance used by the Client
+	Cache() cache.Cache
 }

--- a/pkg/proxy/origins/influxdb/influxdb.go
+++ b/pkg/proxy/origins/influxdb/influxdb.go
@@ -23,9 +23,12 @@ import (
 
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/proxy"
+	"github.com/tricksterproxy/trickster/pkg/proxy/origins"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
 	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
 )
+
+var _ origins.Client = (*Client)(nil)
 
 // Client Implements the Proxy Client Interface
 type Client struct {
@@ -44,7 +47,7 @@ type Client struct {
 
 // NewClient returns a new Client Instance
 func NewClient(name string, oc *oo.Options, router http.Handler,
-	cache cache.Cache) (*Client, error) {
+	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
 	return &Client{name: name, config: oc, router: router, cache: cache,
@@ -61,7 +64,7 @@ func (c *Client) HTTPClient() *http.Client {
 	return c.webClient
 }
 
-// Cache returns and handle to the Cache instance used by the Client
+// Cache returns a handle to the Cache instance used by the Client
 func (c *Client) Cache() cache.Cache {
 	return c.cache
 }

--- a/pkg/proxy/origins/irondb/irondb.go
+++ b/pkg/proxy/origins/irondb/irondb.go
@@ -23,10 +23,13 @@ import (
 
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/proxy"
+	"github.com/tricksterproxy/trickster/pkg/proxy/origins"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
 	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
 )
+
+var _ origins.Client = (*Client)(nil)
 
 // IRONdb API path segments.
 const (
@@ -85,7 +88,7 @@ type Client struct {
 
 // NewClient returns a new Client Instance
 func NewClient(name string, oc *oo.Options, router http.Handler,
-	cache cache.Cache) (*Client, error) {
+	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
 	client := &Client{name: name, config: oc, router: router, cache: cache,

--- a/pkg/proxy/origins/mock_client_test.go
+++ b/pkg/proxy/origins/mock_client_test.go
@@ -52,3 +52,7 @@ func (c *TestClient) Router() http.Handler {
 }
 
 func (c *TestClient) SetCache(cc cache.Cache) {}
+
+func (c *TestClient) Cache() cache.Cache {
+	return nil
+}

--- a/pkg/proxy/origins/prometheus/prometheus.go
+++ b/pkg/proxy/origins/prometheus/prometheus.go
@@ -29,11 +29,14 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/proxy"
 	"github.com/tricksterproxy/trickster/pkg/proxy/errors"
+	"github.com/tricksterproxy/trickster/pkg/proxy/origins"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
 	tt "github.com/tricksterproxy/trickster/pkg/proxy/timeconv"
 	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
 )
+
+var _ origins.Client = (*Client)(nil)
 
 // Prometheus API
 const (
@@ -78,7 +81,7 @@ type Client struct {
 
 // NewClient returns a new Client Instance
 func NewClient(name string, oc *oo.Options, router http.Handler,
-	cache cache.Cache) (*Client, error) {
+	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
 	return &Client{name: name, config: oc, router: router, cache: cache,

--- a/pkg/proxy/origins/reverseproxycache/rpc.go
+++ b/pkg/proxy/origins/reverseproxycache/rpc.go
@@ -23,9 +23,12 @@ import (
 
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/proxy"
+	"github.com/tricksterproxy/trickster/pkg/proxy/origins"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
 	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
 )
+
+var _ origins.Client = (*Client)(nil)
 
 // Client Implements the Proxy Client Interface
 type Client struct {
@@ -44,7 +47,7 @@ type Client struct {
 
 // NewClient returns a new Client Instance
 func NewClient(name string, oc *oo.Options, router http.Handler,
-	cache cache.Cache) (*Client, error) {
+	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
 	return &Client{name: name, config: oc, router: router, cache: cache,

--- a/pkg/proxy/origins/timeseries_client.go
+++ b/pkg/proxy/origins/timeseries_client.go
@@ -55,7 +55,7 @@ type TimeseriesClient interface {
 	HTTPClient() *http.Client
 	// SetCache sets the Cache object the client will use when caching origin content
 	SetCache(cache.Cache)
-	// Cache returns a handle to hte Cache object used by the client
+	// Cache returns a handle to the Cache object used by the client
 	Cache() cache.Cache
 	// Router returns a Router that handles HTTP Requests for this client
 	Router() http.Handler

--- a/pkg/proxy/origins/timeseries_client.go
+++ b/pkg/proxy/origins/timeseries_client.go
@@ -55,6 +55,8 @@ type TimeseriesClient interface {
 	HTTPClient() *http.Client
 	// SetCache sets the Cache object the client will use when caching origin content
 	SetCache(cache.Cache)
+	// Cache returns a handle to hte Cache object used by the client
+	Cache() cache.Cache
 	// Router returns a Router that handles HTTP Requests for this client
 	Router() http.Handler
 }


### PR DESCRIPTION
This is just some minor tidying that helps ensure the origin clients are implementing the proxy client interface. I assumed/hoped `Cache` was acceptable to add to the interface, but am fine with the possibility it was intentionally left out.