### PR TITLE
Ffw post fixes

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -321,6 +321,9 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request) {
 						tl.Pairs{"body": string(body)})
 					return
 				}
+				doc.headerLock.Lock()
+				headers.Merge(doc.Headers, resp.Header)
+				doc.headerLock.Unlock()
 				uncachedValueCount += nts.ValueCount()
 				nts.SetStep(trq.Step)
 				nts.SetExtents([]timeseries.Extent{*e})

--- a/pkg/proxy/engines/key.go
+++ b/pkg/proxy/engines/key.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -58,13 +57,10 @@ func (pr *proxyRequest) DeriveCacheKey(templateURL *url.URL, extra string) strin
 	var b []byte
 	if templateURL != nil {
 		params = templateURL.Query()
-	} else if r.Method == http.MethodPost {
-		b, _ = ioutil.ReadAll(r.Body)
-		r.ParseForm()
-		params = r.PostForm
-		r.Body = ioutil.NopCloser(bytes.NewReader(b))
-	} else if r.URL != nil {
-		params = r.URL.Query()
+	} else {
+		var s string
+		params, s, _ = request.GetRequestValues(r)
+		b = []byte(s)
 	}
 
 	if pc.KeyHasher != nil && len(pc.KeyHasher) == 1 {

--- a/pkg/proxy/engines/key_test.go
+++ b/pkg/proxy/engines/key_test.go
@@ -152,7 +152,7 @@ func TestDeriveCacheKey(t *testing.T) {
 		t.Errorf("expected %s got %s", "407aba34f02c87f6898a6d80b01f38a4", ck)
 	}
 
-	const expected = "1cbe3eb3b2a3c2cb5b445c80c98e76ee"
+	const expected = "cb84ad010abb4d0f864470540a46f137"
 
 	tr = httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", bytes.NewReader([]byte("field1=value1")))
 	tr = tr.WithContext(ct.WithResources(context.Background(), newResources()))

--- a/pkg/proxy/origins/clickhouse/clickhouse.go
+++ b/pkg/proxy/origins/clickhouse/clickhouse.go
@@ -54,6 +54,8 @@ func NewClient(name string, oc *oo.Options, router http.Handler,
 	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
+	// explicitly disable Fast Forward for this client
+	oc.FastForwardDisable = true
 	return &Client{name: name, config: oc, router: router, cache: cache,
 		baseUpstreamURL: bur, webClient: c}, err
 }

--- a/pkg/proxy/origins/clickhouse/stubs.go
+++ b/pkg/proxy/origins/clickhouse/stubs.go
@@ -18,7 +18,6 @@ package clickhouse
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
 )
@@ -28,8 +27,8 @@ import (
 
 // Series (timeseries.Timeseries Interface) stub funcs
 
-// FastForwardURL is not used for ClickHouse and is here to conform to the Proxy Client interface
-func (c *Client) FastForwardURL(r *http.Request) (*url.URL, error) {
+// FastForwardRequest is not used for ClickHouse and is here to conform to the Proxy Client interface
+func (c *Client) FastForwardRequest(r *http.Request) (*http.Request, error) {
 	return nil, nil
 }
 

--- a/pkg/proxy/origins/clickhouse/stubs_test.go
+++ b/pkg/proxy/origins/clickhouse/stubs_test.go
@@ -23,11 +23,10 @@ import (
 func TestFastForwardURL(t *testing.T) {
 
 	client := &Client{}
-	u, err := client.FastForwardURL(nil)
-	if u != nil {
-		t.Errorf("Expected nil url, got %s", u)
+	r, err := client.FastForwardRequest(nil)
+	if r != nil {
+		t.Errorf("Expected nil url, got %v", r)
 	}
-
 	if err != nil {
 		t.Errorf("Expected nil err, got %s", err)
 	}

--- a/pkg/proxy/origins/influxdb/influxdb.go
+++ b/pkg/proxy/origins/influxdb/influxdb.go
@@ -50,6 +50,8 @@ func NewClient(name string, oc *oo.Options, router http.Handler,
 	cache cache.Cache) (origins.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
+	// explicitly disable Fast Forward for this client
+	oc.FastForwardDisable = true
 	return &Client{name: name, config: oc, router: router, cache: cache,
 		webClient: c, baseUpstreamURL: bur}, err
 }

--- a/pkg/proxy/origins/influxdb/stubs.go
+++ b/pkg/proxy/origins/influxdb/stubs.go
@@ -18,7 +18,6 @@ package influxdb
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
 )
@@ -28,8 +27,8 @@ import (
 
 // Series (timeseries.Timeseries Interface) stub funcs
 
-// FastForwardURL is not used for InfluxDB and is here to conform to the Proxy Client interface
-func (c Client) FastForwardURL(r *http.Request) (*url.URL, error) {
+// FastForwardRequest is not used for InfluxDB and is here to conform to the Proxy Client interface
+func (c Client) FastForwardRequest(r *http.Request) (*http.Request, error) {
 	return nil, nil
 }
 

--- a/pkg/proxy/origins/influxdb/stubs_test.go
+++ b/pkg/proxy/origins/influxdb/stubs_test.go
@@ -23,11 +23,10 @@ import (
 func TestFastForwardURL(t *testing.T) {
 
 	client := &Client{}
-	u, err := client.FastForwardURL(nil)
-	if u != nil {
-		t.Errorf("Expected nil url, got %s", u)
+	r, err := client.FastForwardRequest(nil)
+	if r != nil {
+		t.Errorf("Expected nil url, got %v", r)
 	}
-
 	if err != nil {
 		t.Errorf("Expected nil err, got %s", err)
 	}

--- a/pkg/proxy/origins/irondb/handler_caql_test.go
+++ b/pkg/proxy/origins/irondb/handler_caql_test.go
@@ -181,7 +181,7 @@ func TestCaqlHandlerParseTimeRangeQuery(t *testing.T) {
 
 }
 
-func TestCaqlHandlerFastForwardURLError(t *testing.T) {
+func TestCaqlHandlerFastForwardRequestError(t *testing.T) {
 
 	client := &Client{name: "test"}
 	_, _, r, _, err := tu.NewTestInstance("", client.DefaultPathConfigs, 200, "{}",
@@ -189,7 +189,7 @@ func TestCaqlHandlerFastForwardURLError(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, err = client.caqlHandlerFastForwardURL(r)
+	_, err = client.caqlHandlerFastForwardRequest(r)
 	if err == nil {
 		t.Errorf("expected error: %s", "invalid parameters")
 	}

--- a/pkg/proxy/origins/irondb/handler_histogram.go
+++ b/pkg/proxy/origins/irondb/handler_histogram.go
@@ -17,6 +17,7 @@
 package irondb
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/url"
@@ -137,14 +138,15 @@ func (c Client) histogramHandlerDeriveCacheKey(path string, params url.Values,
 
 // histogramHandlerFastForwardURL returns the url to fetch the Fast Forward value
 // based on a timerange URL.
-func (c *Client) histogramHandlerFastForwardURL(
-	r *http.Request) (*url.URL, error) {
+func (c *Client) histogramHandlerFastForwardRequest(
+	r *http.Request) (*http.Request, error) {
 
 	rsc := request.GetResources(r)
+	trq := rsc.TimeRangeQuery
 
 	var err error
-	u := urls.Clone(r.URL)
-	trq := rsc.TimeRangeQuery
+	nr := r.Clone(context.Background())
+	u := nr.URL
 	if trq == nil {
 		trq, err = c.ParseTimeRangeQuery(r)
 		if err != nil {
@@ -170,5 +172,6 @@ func (c *Client) histogramHandlerFastForwardURL(
 	sb.WriteString("/" + strconv.FormatInt(time.Unix(end, 0).Unix(), 10))
 	sb.WriteString("/" + strings.Join(ps[3:], "/"))
 	u.Path = sb.String()
-	return u, nil
+
+	return nr, nil
 }

--- a/pkg/proxy/origins/irondb/handler_histogram_test.go
+++ b/pkg/proxy/origins/irondb/handler_histogram_test.go
@@ -203,7 +203,7 @@ func TestHistogramHandlerSetExtent(t *testing.T) {
 
 }
 
-func TestHistogramHandlerFastForwardURLError(t *testing.T) {
+func TestHistogramHandlerFastForwardRequestError(t *testing.T) {
 
 	// provide bad URL with no TimeRange query params
 	hc := tu.NewTestWebClient()
@@ -220,14 +220,14 @@ func TestHistogramHandlerFastForwardURLError(t *testing.T) {
 	r = request.SetResources(r, rsc)
 
 	r.URL.Path = "/histogram/x/900/300/00112233-4455-6677-8899-aabbccddeeff/metric"
-	_, err = client.histogramHandlerFastForwardURL(r)
+	_, err = client.histogramHandlerFastForwardRequest(r)
 	if err == nil {
 		t.Errorf("expected error: %s", "invalid parameters")
 	}
 
 	r.URL.Path = "/a/900/900/300/00112233-4455-6677-8899-aabbccddeeff/metric"
 	rsc.TimeRangeQuery = &timeseries.TimeRangeQuery{Step: 300 * time.Second}
-	_, err = client.histogramHandlerFastForwardURL(r)
+	_, err = client.histogramHandlerFastForwardRequest(r)
 	if err == nil {
 		t.Errorf("expected error: %s", "invalid parameters")
 	}

--- a/pkg/proxy/origins/irondb/handler_rollup.go
+++ b/pkg/proxy/origins/irondb/handler_rollup.go
@@ -17,8 +17,8 @@
 package irondb
 
 import (
+	"context"
 	"net/http"
-	"net/url"
 	"time"
 
 	"github.com/tricksterproxy/trickster/pkg/proxy/engines"
@@ -103,15 +103,16 @@ func (c *Client) rollupHandlerParseTimeRangeQuery(
 
 // rollupHandlerFastForwardURL returns the url to fetch the Fast Forward value
 // based on a timerange URL.
-func (c *Client) rollupHandlerFastForwardURL(
-	r *http.Request) (*url.URL, error) {
+func (c *Client) rollupHandlerFastForwardRequest(
+	r *http.Request) (*http.Request, error) {
 
 	rsc := request.GetResources(r)
 	trq := rsc.TimeRangeQuery
 
+	nr := r.Clone(context.Background())
+	v, _, _ := request.GetRequestValues(nr)
 	var err error
-	u := urls.Clone(r.URL)
-	q := u.Query()
+
 	if trq == nil {
 		trq, err = c.ParseTimeRangeQuery(r)
 		if err != nil {
@@ -122,8 +123,8 @@ func (c *Client) rollupHandlerFastForwardURL(
 	now := time.Now().Unix()
 	start := now - (now % int64(trq.Step.Seconds()))
 	end := start + int64(trq.Step.Seconds())
-	q.Set(upStart, formatTimestamp(time.Unix(start, 0), true))
-	q.Set(upEnd, formatTimestamp(time.Unix(end, 0), true))
-	u.RawQuery = q.Encode()
-	return u, nil
+	v.Set(upStart, formatTimestamp(time.Unix(start, 0), true))
+	v.Set(upEnd, formatTimestamp(time.Unix(end, 0), true))
+	request.SetRequestValues(nr, v)
+	return nr, nil
 }

--- a/pkg/proxy/origins/irondb/handler_rollup_test.go
+++ b/pkg/proxy/origins/irondb/handler_rollup_test.go
@@ -168,7 +168,7 @@ func TestRollupHandlerParseTimeRangeQuery(t *testing.T) {
 
 }
 
-func TestRollupHandlerFastForwardURLError(t *testing.T) {
+func TestRollupHandlerFastForwardRequestError(t *testing.T) {
 
 	client := &Client{name: "test"}
 	_, _, r, hc, err := tu.NewTestInstance("", client.DefaultPathConfigs,
@@ -182,7 +182,7 @@ func TestRollupHandlerFastForwardURLError(t *testing.T) {
 	client.config = rsc.OriginConfig
 	rsc.OriginClient = client
 
-	_, err = client.rollupHandlerFastForwardURL(r)
+	_, err = client.rollupHandlerFastForwardRequest(r)
 	if err == nil {
 		t.Errorf("expected error: %s", "invalid parameters")
 	}

--- a/pkg/proxy/origins/irondb/url.go
+++ b/pkg/proxy/origins/irondb/url.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -43,9 +42,9 @@ func (c Client) SetExtent(r *http.Request, trq *timeseries.TimeRangeQuery, exten
 	}
 }
 
-// FastForwardURL returns the url to fetch the Fast Forward value based on a
-// timerange URL.
-func (c *Client) FastForwardURL(r *http.Request) (*url.URL, error) {
+// FastForwardRequest returns an *http.Request crafted to collect Fast Forward
+// data from the Origin, based on the provided HTTP Request
+func (c *Client) FastForwardRequest(r *http.Request) (*http.Request, error) {
 
 	rsc := request.GetResources(r)
 	if rsc == nil || rsc.PathConfig == nil {
@@ -54,11 +53,11 @@ func (c *Client) FastForwardURL(r *http.Request) (*url.URL, error) {
 
 	switch rsc.PathConfig.HandlerName {
 	case "RollupHandler":
-		return c.rollupHandlerFastForwardURL(r)
+		return c.rollupHandlerFastForwardRequest(r)
 	case "HistogramHandler":
-		return c.histogramHandlerFastForwardURL(r)
+		return c.histogramHandlerFastForwardRequest(r)
 	case "CAQLHandler":
-		return c.caqlHandlerFastForwardURL(r)
+		return c.caqlHandlerFastForwardRequest(r)
 	}
 
 	return nil, fmt.Errorf("unknown handler name: %s", rsc.PathConfig.HandlerName)
@@ -121,7 +120,7 @@ func (c *Client) ParseTimeRangeQuery(
 	r *http.Request) (*timeseries.TimeRangeQuery, error) {
 
 	rsc := request.GetResources(r)
-	if rsc.PathConfig == nil {
+	if rsc == nil || rsc.PathConfig == nil {
 		return nil, errors.New("missing path config")
 	}
 

--- a/pkg/proxy/origins/irondb/url_test.go
+++ b/pkg/proxy/origins/irondb/url_test.go
@@ -18,6 +18,7 @@ package irondb
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -210,7 +211,7 @@ func TestFastForwardURL(t *testing.T) {
 	oc := conf.Origins["default"]
 	client := &Client{config: oc}
 
-	_, err = client.FastForwardURL(nil)
+	_, err = client.FastForwardRequest(nil)
 	if err == nil {
 		t.Error("expected error")
 	}
@@ -285,9 +286,10 @@ func TestFastForwardURL(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 
 			r, _ := http.NewRequest(http.MethodGet, c.u.String(), nil)
+			r = r.WithContext(context.Background())
 			rsc.PathConfig = c.p
-			r = request.SetResources(r, rsc)
-			u, err := client.FastForwardURL(r)
+			nr := request.SetResources(r, rsc)
+			fr, err := client.FastForwardRequest(nr)
 			if c.handler != "ProxyHandler" && err != nil {
 				t.Error(err)
 			}
@@ -296,9 +298,9 @@ func TestFastForwardURL(t *testing.T) {
 				t.Errorf("expected error: %s", "unknown handler name")
 			}
 
-			if u != nil {
-				if u.String() != c.exp {
-					t.Errorf("Expected URL: %v, got: %v", c.exp, u.String())
+			if fr != nil && fr.URL != nil {
+				if fr.URL.String() != c.exp {
+					t.Errorf("Expected URL: %v, got: %v", c.exp, fr.URL.String())
 				}
 			}
 		})

--- a/pkg/proxy/origins/prometheus/url.go
+++ b/pkg/proxy/origins/prometheus/url.go
@@ -17,64 +17,34 @@
 package prometheus
 
 import (
-	"bytes"
-	"io/ioutil"
+	"context"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 
-	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
+	"github.com/tricksterproxy/trickster/pkg/proxy/request"
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
 )
 
 // SetExtent will change the upstream request query to use the provided Extent
 func (c *Client) SetExtent(r *http.Request, trq *timeseries.TimeRangeQuery, extent *timeseries.Extent) {
-	var qp url.Values
-	if r.Method == http.MethodPost {
-		r.ParseForm()
-		qp = r.PostForm
-	} else {
-		qp = r.URL.Query()
-	}
-
-	qp.Set(upStart, strconv.FormatInt(extent.Start.Unix(), 10))
-	qp.Set(upEnd, strconv.FormatInt(extent.End.Unix(), 10))
-	s := qp.Encode()
-
-	if r.Method == http.MethodPost {
-		r.ContentLength = int64(len(s))
-		r.Body = ioutil.NopCloser(bytes.NewBufferString(s))
-	} else {
-		r.URL.RawQuery = s
-	}
+	v, _, _ := request.GetRequestValues(r)
+	v.Set(upStart, strconv.FormatInt(extent.Start.Unix(), 10))
+	v.Set(upEnd, strconv.FormatInt(extent.End.Unix(), 10))
+	request.SetRequestValues(r, v)
 }
 
-// FastForwardURL returns the url to fetch the Fast Forward value based on a timerange url
-func (c *Client) FastForwardURL(r *http.Request) (*url.URL, error) {
-
-	u := urls.Clone(r.URL)
-
-	if strings.HasSuffix(u.Path, "/query_range") {
-		u.Path = u.Path[0 : len(u.Path)-6]
+// FastForwardRequest returns an *http.Request crafted to collect Fast Forward
+// data from the Origin, based on the provided HTTP Request
+func (c *Client) FastForwardRequest(r *http.Request) (*http.Request, error) {
+	nr := r.Clone(context.Background())
+	if strings.HasSuffix(nr.URL.Path, "/query_range") {
+		nr.URL.Path = nr.URL.Path[0 : len(nr.URL.Path)-6]
 	}
-
-	var b []byte
-	var qp url.Values
-
-	if r.Method == http.MethodPost {
-		b, _ = ioutil.ReadAll(r.Body)
-		r.ParseForm()
-		qp = r.PostForm
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
-	} else {
-		qp = r.URL.Query()
-	}
-
-	qp.Del(upStart)
-	qp.Del(upEnd)
-	qp.Del(upStep)
-	u.RawQuery = qp.Encode()
-
-	return u, nil
+	v, _, _ := request.GetRequestValues(nr)
+	v.Del(upStart)
+	v.Del(upEnd)
+	v.Del(upStep)
+	request.SetRequestValues(nr, v)
+	return nr, nil
 }

--- a/pkg/proxy/origins/prometheus/url_test.go
+++ b/pkg/proxy/origins/prometheus/url_test.go
@@ -87,20 +87,20 @@ func TestFastForwardURL(t *testing.T) {
 	u := &url.URL{Path: "/query_range", RawQuery: "q=up&start=1&end=1&step=1"}
 	r, _ := http.NewRequest(http.MethodGet, u.String(), nil)
 
-	u2, err := client.FastForwardURL(r)
+	r2, err := client.FastForwardRequest(r)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if expected != u2.RawQuery {
-		t.Errorf("\nexpected [%s]\ngot [%s]", expected, u2.RawQuery)
+	if expected != r2.URL.RawQuery {
+		t.Errorf("\nexpected [%s]\ngot [%s]", expected, r2.URL.RawQuery)
 	}
 
-	u2.RawQuery = ""
+	r2.URL.RawQuery = ""
 	b := bytes.NewBufferString(expected)
-	r, _ = http.NewRequest(http.MethodPost, u2.String(), b)
+	r, _ = http.NewRequest(http.MethodPost, r2.URL.String(), b)
 
-	_, err = client.FastForwardURL(r)
+	r2, err = client.FastForwardRequest(r)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/proxy/origins/timeseries_client.go
+++ b/pkg/proxy/origins/timeseries_client.go
@@ -18,7 +18,6 @@ package origins
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	oo "github.com/tricksterproxy/trickster/pkg/proxy/origins/options"
@@ -38,9 +37,11 @@ type TimeseriesClient interface {
 	Configuration() *oo.Options
 	// Name returns the name of the origin the Proxy Client is handling
 	Name() string
-	// FastForwardURL returns the URL to the origin to collect Fast Forward
-	// data points based on the provided HTTP Request
-	FastForwardURL(*http.Request) (*url.URL, error)
+	// FastForwardRequest returns an *http.Request crafted to collect Fast Forward
+	// data from the Origin, based on the provided HTTP Request
+	// If the inbound request is POST/PUT/PATCH, a non-nil body must be set with the query parameters,
+	// in lieu of updated url query values, in the returned request
+	FastForwardRequest(*http.Request) (*http.Request, error)
 	// SetExtent will update an upstream request's timerange
 	// parameters based on the provided timeseries.Extent
 	SetExtent(*http.Request, *timeseries.TimeRangeQuery, *timeseries.Extent)

--- a/pkg/proxy/request/request.go
+++ b/pkg/proxy/request/request.go
@@ -51,7 +51,7 @@ func GetRequestValues(r *http.Request) (url.Values, string, bool) {
 // regardless of method
 func SetRequestValues(r *http.Request, v url.Values) {
 	s := v.Encode()
-	if methods.HasBody(r.Method) {
+	if !methods.HasBody(r.Method) {
 		r.URL.RawQuery = s
 	} else {
 		// reset the body

--- a/pkg/proxy/request/request.go
+++ b/pkg/proxy/request/request.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 	"github.com/tricksterproxy/trickster/pkg/proxy/methods"
 )
 
@@ -36,6 +37,12 @@ func GetRequestValues(r *http.Request) (url.Values, string, bool) {
 	if !methods.HasBody(r.Method) {
 		v = r.URL.Query()
 		s = r.URL.RawQuery
+	} else if r.Header.Get(headers.NameContentType) == headers.ValueApplicationJSON {
+		v = url.Values{}
+		b, _ := ioutil.ReadAll(r.Body)
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(b))
+		s = string(b)
+		isBody = true
 	} else {
 		r.ParseForm()
 		v = r.PostForm


### PR DESCRIPTION
this PR ensures that POST requests are fully supported with Fast Forward. It also administratively sets` FastForwardDisabled` to `true` on InfluxDB and ClickHouse, since their accelerators do not currently implement the feature.

The key change was to replace `FastForwardURL()` in the Timeseries Client interface to `FastForwardRequest()` which handles the entire FF Request creation instead of just url manipulation, allowing access to the request body for POSTs.