### PR TITLE
Fix losing series when multiple statements in query.

### DIFF
--- a/pkg/proxy/origins/influxdb/series.go
+++ b/pkg/proxy/origins/influxdb/series.go
@@ -429,10 +429,10 @@ func (se *SeriesEnvelope) Sort() {
 
 	var hasWarned bool
 	tsm := map[time.Time]bool{}
-	m := make(map[int64][]interface{})
 	if ti := str.IndexOfString(se.Results[0].Series[0].Columns, "time"); ti != -1 {
 		for ri := range se.Results {
 			for si := range se.Results[ri].Series {
+				m := make(map[int64][]interface{})
 				keys := make([]int64, 0, len(m))
 				for _, v := range se.Results[ri].Series[si].Values {
 					wg.Add(1)


### PR DESCRIPTION
When multiple statement in query series metric are lost. Refers to issue #460 