### PR TITLE
env URL name fix

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -6,7 +6,7 @@ There are 3 ways to configure Trickster, listed here in the order of evaluation.
 * Environment Variables
 * Command Line Arguments
 
-Note that while the Confifguration file provides a very robust number of knobs you can adjust, the ENV and CLI Args options support only basic use cases.
+Note that while the Configuration file provides a very robust number of knobs you can adjust, the ENV and CLI Args options support only basic use cases.
 
 ## Internal Defaults
 
@@ -24,7 +24,7 @@ Refer to [cmd/trickster/conf/example.conf](../cmd/trickster/conf/example.conf) f
 
 Trickster will then check for and evaluate the following Environment Variables:
 
-* `TRK_ORIGIN=http://prometheus.example.com:9090` - The default origin for proxying all http requests
+* `TRK_ORIGIN_URL=http://prometheus.example.com:9090` - The default origin for proxying all http requests
 * `TRK_ORIGIN_TYPE=prometheus` - The type of [supported origin server](./supported-origin-types.md)
 * `TRK_LOG_LEVEL=INFO` - Level of Logging that Trickster will output
 * `TRK_PROXY_PORT=8480` -Listener port for the HTTP Proxy Endpoint


### PR DESCRIPTION
This brings the documentation into alignment with the actual environment variable name that's required. Also one tiny spelling fix. :smile:

Issue this is in reference to: https://github.com/tricksterproxy/trickster/issues/490