### PR TITLE
Updated references from old names to new ones

### DIFF
--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -78,10 +78,10 @@ data:
     # [caches]
 
         # [caches.default]
-        ## cache_type defines what kind of cache Trickster uses
+        ## provider defines what kind of cache Trickster uses
         ## options are 'bbolt', 'badger', 'filesystem', 'memory', and 'redis'
         ## The default is 'memory'.
-        # cache_type = 'memory'
+        # provider = 'memory'
 
             ### Configuration options for the Cache Index
             ## The Cache Index handles key management and retention for bbolt, filesystem and memory
@@ -217,7 +217,7 @@ data:
         ## Example of a second cache, sans comments, that origin configs below could use with: cache_name = 'bbolt_example'
         #
         # [caches.bbolt_example]
-        # cache_type = 'bbolt'
+        # provider = 'bbolt'
 
             # [caches.bbolt_example.bbolt]
             # filename = 'trickster.db'
@@ -259,10 +259,10 @@ data:
         # access this origin via http[s]://trickster-fqdn/default/ unless path_routing_disabled is true
         [origins.default]
 
-        # origin_type identifies the origin type.
+        # provider identifies the origin type.
         # Valid options are: 'prometheus', 'influxdb', 'clickhouse', 'irondb', 'reverseproxycache' (or just 'rpc')
-        # origin_type is a required configuration value
-        origin_type = 'prometheus'
+        # provider is a required configuration value
+        provider = 'prometheus'
 
         # origin_url provides the base upstream URL for all proxied requests to this origin.
         # it can be as simple as http://example.com or as complex as https://example.com:8443/path/prefix
@@ -300,7 +300,7 @@ data:
         # path_routing_disabled = false
 
         ## rule_name provides the name of the rule config to be used by this origin.
-        ## This is only effective if the origin_type is 'rule'
+        ## This is only effective if the provider is 'rule'
         # rule_name = 'example-rule'
 
         ## req_rewriter_name is the name of a configured rewriter (in [request_rewriters]) that will modify the request prior to
@@ -462,7 +462,7 @@ data:
         ## use quotes around FQDNs for host-based routing (see /docs/multi-origin.md).
         # [origins.'foo.example.com']
         # is_default = false
-        # origin_type = 'influxdb'
+        # provider = 'influxdb'
         # origin_url = 'http://influx-origin:8086'
         # cache_name = 'bbolt_example'
         # negative_cache_name = 'general'

--- a/deploy/trickster-demo/docker-compose-data/trickster-config/trickster.conf
+++ b/deploy/trickster-demo/docker-compose-data/trickster-config/trickster.conf
@@ -10,19 +10,19 @@ listen_port = 8480
 
 [caches]
   [caches.fs1]
-  cache_type = 'filesystem'
+  provider = 'filesystem'
     [caches.fs1.filesystem]
     cache_path = '/data/trickster'
     [caches.fs1.index]
     max_size_objects = 512
     max_size_backoff_objects = 128
   [caches.mem1]
-  cache_type = 'memory'
+  provider = 'memory'
     [caches.mem1.index]
     max_size_objects = 512
     max_size_backoff_objects = 128
   [caches.rds1]
-  cache_type = 'redis'
+  provider = 'redis'
     [caches.rds1.redis]
     client_type = 'standard'
     protocol = 'tcp'
@@ -50,31 +50,31 @@ listen_port = 8480
 
 [origins]
   [origins.prom1] # prometheus cached with a memory cache, traces sent to stdout
-  origin_type = 'prometheus'
+  provider = 'prometheus'
   origin_url = 'http://prometheus:9090'
   tracing_name = 'std1'
   cache_name = 'mem1'
 
   [origins.prom2] # prometheus cached with a filesystem cache, traces sent to jaeger collector
-  origin_type = 'prometheus'
+  provider = 'prometheus'
   origin_url = 'http://prometheus:9090'
   tracing_name = 'jc1'
   cache_name = 'fs1'
 
   [origins.sim1] # simulated prometheus cached with a memory cache, traces sent to jaeger agent
-  origin_type = 'prometheus'
+  provider = 'prometheus'
   origin_url = 'http://mockster:8482/prometheus'
   tracing_name = 'ja1'
   cache_name = 'mem1'
 
   [origins.sim2] # simulated prometheus cached with a Redis cache, traces sent to jaeger agent
-  origin_type = 'prometheus'
+  provider = 'prometheus'
   origin_url = 'http://mockster:8482/prometheus'
   tracing_name = 'ja1'
   cache_name = 'rds1'
 
   [origins.rpc1] # memory reverse proxy cache of the byterange request simulation endpoint, traces sent to jager agent
-  origin_type = 'reverseproxycache'
+  provider = 'reverseproxycache'
   origin_url = 'http://mockster:8482/byterange'
   tracing_name = 'ja1'
   cache_name = 'mem1'

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,7 +19,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_frontend_requests_total` (Counter) - Count of front end requests handled by Trickster
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `http_status` - The HTTP response code provided by the origin
     * `path` - the Path portion of the requested URL
@@ -27,7 +27,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_frontend_requests_duration_seconds` (Histogram) - Histogram of front end request durations handled by Trickster
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `http_status` - The HTTP response code provided by the origin
     * `path` - the Path portion of the requested URL
@@ -35,7 +35,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_frontend_written_byte_total` (Counter) - Count of bytes written in front end requests handled by Trickster
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `http_status` - The HTTP response code provided by the origin
     * `path` - the Path portion of the requested URL
@@ -43,7 +43,7 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_proxy_requests_total` (Counter) - The total number of requests Trickster has handled.
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `cache_status` - status codes are described [here](./caches.md#cache-status)
     * `http_status` - The HTTP response code provided by the origin
@@ -52,14 +52,14 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_proxy_points_total` (Counter) - The total number of data points Trickster has handled.
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `cache_status` - status codes are described [here](./caches.md#cache-status)
     * `path` - the Path portion of the requested URL
 
 * `trickster_proxy_request_duration_seconds` (Histogram) - Time required to proxy a given Prometheus query.
   * labels:
     * `origin_name` - the name of the configured origin handling the proxy request
-    * `origin_type` - the type of the configured origin handling the proxy request
+    * `provider` - the type of the configured origin handling the proxy request
     * `method` - the HTTP Method of the proxied request
     * `cache_status` - status codes are described [here](./caches.md#cache-status)
     * `http_status` - The HTTP response code provided by the origin
@@ -80,14 +80,14 @@ The following metrics are available for polling with any Trickster configuration
 * `trickster_cache_operation_objects_total` (Counter) - The total number of objects upon which the Trickster cache has operated.
   * labels:
     * `cache_name` - the name of the configured cache performing the operation$
-    * `cache_type` - the type of the configured cache performing the operation
+    * `provider` - the type of the configured cache performing the operation
     * `operation` - the name of the operation being performed (read, write, etc.)
     * `status` - the result of the operation being performed
 
 * `trickster_cache_operation_bytes_total` (Counter) - The total number of bytes upon which the Trickster cache has operated.
   * labels:
     * `cache_name` - the name of the configured cache performing the operation$
-    * `cache_type` - the type of the configured cache performing the operation
+    * `provider` - the type of the configured cache performing the operation
     * `operation` - the name of the operation being performed (read, write, etc.)
     * `status` - the result of the operation being performed
 
@@ -98,29 +98,29 @@ The following metrics are available only for Caches Types whose object lifecycle
 * `trickster_cache_events_total` (Counter) - The total number of events that change the Trickster cache, such as retention policy evictions.
   * labels:
     * `cache_name` - the name of the configured cache experiencing the event$
-    * `cache_type` - the type of the configured cache experiencing the event
+    * `provider` - the type of the configured cache experiencing the event
     * `event` - the name of the event being performed
     * `reason` - the reason the event occurred
 
 * `trickster_cache_usage_objects` (Gauge) - The current count of objects in the Trickster cache.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache$
+    * `provider` - the type of the configured cache$
 
 * `trickster_cache_usage_bytes` (Gauge) - The current count of bytes in the Trickster cache.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache$
+    * `provider` - the type of the configured cache$
 
 * `trickster_cache_max_usage_objects` (Gauge) - The maximum allowed size of the Trickster cache in objects.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache
+    * `provider` - the type of the configured cache
 
 * `trickster_cache_max_usage_bytes` (Gauge) - The maximum allowed size of the Trickster cache in bytes.
   * labels:
     * `cache_name` - the name of the configured cache$
-    * `cache_type` - the type of the configured cache
+    * `provider` - the type of the configured cache
 
 ---
 

--- a/docs/multi-origin.md
+++ b/docs/multi-origin.md
@@ -35,20 +35,20 @@ Example Path-based Multi-Origin Configuration:
     # origin1 origin
     [origins.origin1]
         origin_url = 'http://prometheus.example.com:9090'
-        origin_type = 'prometheus'
+        provider = 'prometheus'
         cache_name = 'default'
         is_default = true
 
     # "foo" origin
     [origins.foo]
         origin_url = 'http://influxdb-foo.example.com:9090'
-        origin_type = 'influxdb'
+        provider = 'influxdb'
         cache_name = 'default'
 
     # "bar" origin
     [origins.bar]
         origin_url = 'http://prometheus-bar.example.com:9090'
-        origin_type = 'prometheus'
+        provider = 'prometheus'
         cache_name = 'default'
 ```
 
@@ -85,7 +85,7 @@ Example DNS-based Origin Configuration:
     [origins.origin1]
         hosts = [ '1.example.com', '2.example.com' ] # users can route to this origin via these FQDNs, or via `/origin1`
         origin_url = 'http://prometheus.example.com:9090'
-        origin_type = 'prometheus'
+        provider = 'prometheus'
         cache_name = 'default'
         is_default = true
 
@@ -93,14 +93,14 @@ Example DNS-based Origin Configuration:
     [origins.foo]
         hosts = [ 'trickster-foo.example.com' ] # users can route to this origin via these FQDNs, or via `/foo`
         origin_url = 'http://prometheus-foo.example.com:9090'
-        origin_type = 'prometheus'
+        provider = 'prometheus'
         cache_name = 'default'
 
     # "bar" origin
     [origins.bar]
         hosts = [ 'trickster-bar.example.com' ] # users can route to this origin via these FQDNs, or via `/bar`
         origin_url = 'http://prometheus-bar.example.com:9090'
-        origin_type = 'prometheus'
+        provider = 'prometheus'
         cache_name = 'default'
 
 ```
@@ -128,7 +128,7 @@ You may wish for an origin to be inaccessible via the `/origin_name/` path, and 
     [origins.origin1]
         hosts = [ '1.example.com', '2.example.com' ]
         origin_url = 'http://prometheus.example.com:9090'
-        origin_type = 'prometheus'
+        provider = 'prometheus'
         cache_name = 'default'
         is_default = false
         path_routing_disabled = true

--- a/docs/negative-caching.md
+++ b/docs/negative-caching.md
@@ -25,10 +25,10 @@ You can define multiple negative cache configurations, and reference them by nam
 
 [origins]
     [origins.default]
-    origin_type = 'rpc'
+    provider = 'rpc'
     # by default will assume negative_cache_name = 'default'
     
     [origins.another]
-    origin_type = 'rpc'
+    provider = 'rpc'
     negative_cache_name = 'foo'
 ```

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -46,7 +46,7 @@ You can configure paths send inbound requests through a request rewriter that ca
 [origins]
 
     [origins.default]
-    origin_type = 'rpc'
+    provider = 'rpc'
     origin_url = 'http://example.com'
 
         [origins.default.paths]
@@ -118,7 +118,7 @@ To include the `requestType`, `table`, `fields`, and `filter` fields from this d
 [origins]
 
     [origins.default]
-    origin_type = 'rpc'
+    provider = 'rpc'
 
         [origins.default.paths]
 
@@ -218,7 +218,7 @@ Examples of customizing Path Configs for Origin Types with Pre-Definitions:
 [origins]
 
     [origins.default]
-    origin_type = 'prometheus'
+    provider = 'prometheus'
 
         [origins.default.paths]
 

--- a/docs/range_request.md
+++ b/docs/range_request.md
@@ -13,7 +13,7 @@ In the event that an upstream origin supports serving a single Range, but does n
 ```toml
 [origins]
     [origins.default]
-    origin_type = 'reverseproxycache'
+    provider = 'reverseproxycache'
     origin_url = 'http://example.com/'
     dearticulate_upstream_ranges = true
 ```
@@ -33,7 +33,7 @@ There may, however, be cases where you do not want to enable Multipart Range sup
 ```toml
 [origins]
     [origins.default]
-    origin_type = 'reverseproxycache'
+    provider = 'reverseproxycache'
     origin_url = 'http://example.com/'
     dearticulate_upstream_ranges = true
     multipart_ranges_disabled = true

--- a/docs/rule.md
+++ b/docs/rule.md
@@ -94,15 +94,15 @@ Optional Case Parts
 [origins]
 
   [origins.example]
-  origin_type = 'rule'
+  provider = 'rule'
   rule_name = 'example-user-router'
 
   [origins.example-reader-cluster]
-  origin_type = 'rpc'
+  provider = 'rpc'
   origin_url = 'http://reader-cluster.example.com'
 
   [origins.example-writer-cluster]
-  origin_type = 'rpc'
+  provider = 'rpc'
   origin_url = 'http://writer-cluster.example.com'
   path_routing_disabled = true  # restrict routing to this origin via rule only
                                 # users cannot directly access via /example-writer-cluster/

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -142,7 +142,7 @@ func init() {
 			Name:      "requests_total",
 			Help:      "Count of front end requests handled by Trickster",
 		},
-		[]string{"origin_name", "origin_type", "method", "path", "http_status"},
+		[]string{"origin_name", "provider", "method", "path", "http_status"},
 	)
 
 	FrontendRequestDuration = prometheus.NewHistogramVec(
@@ -153,7 +153,7 @@ func init() {
 			Help:      "Histogram of front end request durations handled by Trickster",
 			Buckets:   defaultBuckets,
 		},
-		[]string{"origin_name", "origin_type", "method", "path", "http_status"},
+		[]string{"origin_name", "provider", "method", "path", "http_status"},
 	)
 
 	FrontendRequestWrittenBytes = prometheus.NewCounterVec(
@@ -163,7 +163,7 @@ func init() {
 			Name:      "written_bytes_total",
 			Help:      "Count of bytes written in front end requests handled by Trickster",
 		},
-		[]string{"origin_name", "origin_type", "method", "path", "http_status"})
+		[]string{"origin_name", "provider", "method", "path", "http_status"})
 
 	ProxyRequestStatus = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -172,7 +172,7 @@ func init() {
 			Name:      "requests_total",
 			Help:      "Count of downstream client requests handled by Trickster",
 		},
-		[]string{"origin_name", "origin_type", "method", "cache_status", "http_status", "path"},
+		[]string{"origin_name", "provider", "method", "cache_status", "http_status", "path"},
 	)
 
 	ProxyRequestElements = prometheus.NewCounterVec(
@@ -182,7 +182,7 @@ func init() {
 			Name:      "points_total",
 			Help:      "Count of data points in the timeseries returned to the requesting client.",
 		},
-		[]string{"origin_name", "origin_type", "cache_status", "path"},
+		[]string{"origin_name", "provider", "cache_status", "path"},
 	)
 
 	ProxyRequestDuration = prometheus.NewHistogramVec(
@@ -193,7 +193,7 @@ func init() {
 			Help:      "Time required in seconds to proxy a given Prometheus query.",
 			Buckets:   defaultBuckets,
 		},
-		[]string{"origin_name", "origin_type", "method", "status", "http_status", "path"},
+		[]string{"origin_name", "provider", "method", "status", "http_status", "path"},
 	)
 
 	ProxyMaxConnections = prometheus.NewGauge(


### PR DESCRIPTION
Updated "origin_type" and "cache_type" references in documentation referred in these comments (https://github.com/tricksterproxy/trickster/issues/495#issuecomment-702250964 , https://github.com/tricksterproxy/trickster/issues/495#issuecomment-702253173 ) to "provider", resolving https://github.com/tricksterproxy/trickster/issues/495.

Issue was assigned but on seeing that, last update was 5 days ago, and by non-assignee whose PR was merged, encouraged me to resolve.

Please add `hacktoberfest-accepted` label, so that contribution will count towards my hacktoberfest participation.
Thanks!