### PR TITLE
2.0 fix log caller

### DIFF
--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -38,6 +38,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/runtime"
 	tr "github.com/tricksterproxy/trickster/pkg/tracing/registration"
 	"github.com/tricksterproxy/trickster/pkg/util/metrics"
+
+	"github.com/go-stack/stack"
 )
 
 var cfgLock = &sync.Mutex{}
@@ -102,7 +104,7 @@ func applyConfig(conf, oldConf *config.Config, wg *sync.WaitGroup, log *tl.Logge
 	log = applyLoggingConfig(conf, oldConf, log)
 
 	for _, w := range conf.LoaderWarnings {
-		tl.Warn(log, w, tl.Pairs{})
+		tl.Warn(log, stack.Caller(0), w, tl.Pairs{})
 	}
 
 	//Register Tracing Configurations
@@ -234,7 +236,7 @@ func applyCachingConfig(c, oc *config.Config, logger *tl.Logger,
 
 func initLogger(c *config.Config) *tl.Logger {
 	log := tl.New(c)
-	tl.Info(log, "application loaded from configuration",
+	tl.Info(log, stack.Caller(0), "application loaded from configuration",
 		tl.Pairs{
 			"name":      runtime.ApplicationName,
 			"version":   runtime.ApplicationVersion,
@@ -266,10 +268,10 @@ func handleStartupIssue(event string, detail tl.Pairs, logger *tl.Logger, exitFa
 	if event != "" {
 		if logger != nil {
 			if exitFatal {
-				tl.Fatal(logger, 1, event, detail)
+				tl.Fatal(logger, stack.Caller(0), 1, event, detail)
 				return
 			}
-			tl.Warn(logger, event, detail)
+			tl.Warn(logger, stack.Caller(0), event, detail)
 			return
 		}
 		fmt.Println(event)

--- a/cmd/trickster/listeners.go
+++ b/cmd/trickster/listeners.go
@@ -29,6 +29,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/routing"
 	"github.com/tricksterproxy/trickster/pkg/tracing"
 	"github.com/tricksterproxy/trickster/pkg/util/metrics"
+
+	"github.com/go-stack/stack"
 )
 
 var lg = listener.NewListenerGroup()
@@ -64,7 +66,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 	}
 
 	if oldConf != nil && oldConf.Frontend.ConnectionsLimit != conf.Frontend.ConnectionsLimit {
-		tl.Warn(log, "connections limit change requires a process restart. listeners not updated.",
+		tl.Warn(log, stack.Caller(0), "connections limit change requires a process restart. listeners not updated.",
 			tl.Pairs{"oldLimit": oldConf.Frontend.ConnectionsLimit,
 				"newLimit": conf.Frontend.ConnectionsLimit})
 		return
@@ -85,7 +87,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		lg.DrainAndClose("tlsListener", drainTimeout)
 		tlsConfig, err = conf.TLSCertConfig()
 		if err != nil {
-			tl.Error(log, "unable to start tls listener due to certificate error", tl.Pairs{"detail": err})
+			tl.Error(log, stack.Caller(0), "unable to start tls listener due to certificate error", tl.Pairs{"detail": err})
 		} else {
 			wg.Add(1)
 			tracerFlusherSet = true
@@ -101,7 +103,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 	} else if conf.Frontend.ServeTLS && ttls.OptionsChanged(conf, oldConf) {
 		tlsConfig, _ = conf.TLSCertConfig()
 		if err != nil {
-			tl.Error(log, "unable to update tls config to certificate error", tl.Pairs{"detail": err})
+			tl.Error(log, stack.Caller(0), "unable to update tls config to certificate error", tl.Pairs{"detail": err})
 			return
 		}
 		l := lg.Get("tlsListener")

--- a/cmd/trickster/signal.go
+++ b/cmd/trickster/signal.go
@@ -25,6 +25,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/config"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
+
+	"github.com/go-stack/stack"
 )
 
 var hups = make(chan os.Signal, 1)
@@ -45,7 +47,7 @@ func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *tl.Logger,
 			case <-hups:
 				conf.Main.ReloaderLock.Lock()
 				if conf.IsStale() {
-					tl.Warn(log, "configuration reload starting now", tl.Pairs{"source": "sighup"})
+					tl.Warn(log, stack.Caller(0), "configuration reload starting now", tl.Pairs{"source": "sighup"})
 					err := runConfig(conf, wg, log, caches, args, false)
 					if err == nil {
 						conf.Main.ReloaderLock.Unlock()
@@ -53,7 +55,7 @@ func startHupMonitor(conf *config.Config, wg *sync.WaitGroup, log *tl.Logger,
 					}
 				}
 				conf.Main.ReloaderLock.Unlock()
-				tl.Warn(log, "configuration NOT reloaded", tl.Pairs{})
+				tl.Warn(log, stack.Caller(0), "configuration NOT reloaded", tl.Pairs{})
 			case <-conf.Resources.QuitChan:
 				return
 			}

--- a/pkg/cache/badger/badger.go
+++ b/pkg/cache/badger/badger.go
@@ -28,6 +28,7 @@ import (
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
 
 	"github.com/dgraph-io/badger"
+	"github.com/go-stack/stack"
 )
 
 // Cache describes a Badger Cache
@@ -57,7 +58,7 @@ func (c *Cache) Configuration() *options.Options {
 
 // Connect opens the configured Badger key-value store
 func (c *Cache) Connect() error {
-	tl.Info(c.Logger, "badger cache setup", tl.Pairs{"cacheDir": c.Config.Badger.Directory})
+	tl.Info(c.Logger, stack.Caller(0), "badger cache setup", tl.Pairs{"cacheDir": c.Config.Badger.Directory})
 
 	opts := badger.DefaultOptions(c.Config.Badger.Directory)
 	opts.ValueDir = c.Config.Badger.ValueDirectory
@@ -74,7 +75,7 @@ func (c *Cache) Connect() error {
 // Store places the the data into the Badger Cache using the provided Key and TTL
 func (c *Cache) Store(cacheKey string, data []byte, ttl time.Duration) error {
 	metrics.ObserveCacheOperation(c.Name, c.Config.Provider, "set", "none", float64(len(data)))
-	tl.Debug(c.Logger, "badger cache store", tl.Pairs{"key": cacheKey, "ttl": ttl})
+	tl.Debug(c.Logger, stack.Caller(0), "badger cache store", tl.Pairs{"key": cacheKey, "ttl": ttl})
 	return c.dbh.Update(func(txn *badger.Txn) error {
 		return txn.SetEntry(&badger.Entry{Key: []byte(cacheKey), Value: data, ExpiresAt: uint64(time.Now().Add(ttl).Unix())})
 	})
@@ -95,26 +96,26 @@ func (c *Cache) Retrieve(cacheKey string, allowExpired bool) ([]byte, status.Loo
 	})
 
 	if err == nil {
-		tl.Debug(c.Logger, "badger cache retrieve", tl.Pairs{"key": cacheKey})
+		tl.Debug(c.Logger, stack.Caller(0), "badger cache retrieve", tl.Pairs{"key": cacheKey})
 		metrics.ObserveCacheOperation(c.Name, c.Config.Provider, "get", "hit", float64(len(data)))
 		return data, status.LookupStatusHit, nil
 	}
 
 	if err == badger.ErrKeyNotFound {
 		err = cache.ErrKNF
-		tl.Debug(c.Logger, "badger cache miss", tl.Pairs{"key": cacheKey})
+		tl.Debug(c.Logger, stack.Caller(0), "badger cache miss", tl.Pairs{"key": cacheKey})
 		metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.Provider)
 		return nil, status.LookupStatusKeyMiss, err
 	}
 
-	tl.Debug(c.Logger, "badger cache retrieve failed", tl.Pairs{"key": cacheKey, "reason": err.Error()})
+	tl.Debug(c.Logger, stack.Caller(0), "badger cache retrieve failed", tl.Pairs{"key": cacheKey, "reason": err.Error()})
 	metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.Provider)
 	return data, status.LookupStatusError, err
 }
 
 // Remove removes an object in cache, if present
 func (c *Cache) Remove(cacheKey string) {
-	tl.Debug(c.Logger, "badger cache remove", tl.Pairs{"key": cacheKey})
+	tl.Debug(c.Logger, stack.Caller(0), "badger cache remove", tl.Pairs{"key": cacheKey})
 	c.dbh.Update(func(txn *badger.Txn) error {
 		return txn.Delete([]byte(cacheKey))
 	})
@@ -123,7 +124,7 @@ func (c *Cache) Remove(cacheKey string) {
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Badger
 func (c *Cache) BulkRemove(cacheKeys []string) {
-	tl.Debug(c.Logger, "badger cache bulk remove", tl.Pairs{})
+	tl.Debug(c.Logger, stack.Caller(0), "badger cache bulk remove", tl.Pairs{})
 
 	c.dbh.Update(func(txn *badger.Txn) error {
 		for _, key := range cacheKeys {
@@ -152,7 +153,7 @@ func (c *Cache) SetTTL(cacheKey string, ttl time.Duration) {
 		data, _ = item.ValueCopy(nil)
 		return txn.SetEntry(&badger.Entry{Key: []byte(cacheKey), Value: data, ExpiresAt: uint64(time.Now().Add(ttl).Unix())})
 	})
-	tl.Debug(c.Logger, "badger cache update-ttl", tl.Pairs{"key": cacheKey, "ttl": ttl, "success": err == nil})
+	tl.Debug(c.Logger, stack.Caller(0), "badger cache update-ttl", tl.Pairs{"key": cacheKey, "ttl": ttl, "success": err == nil})
 	if err == nil {
 		metrics.ObserveCacheOperation(c.Name, c.Config.Provider, "update-ttl", "none", 0)
 	}

--- a/pkg/cache/bbolt/bbolt.go
+++ b/pkg/cache/bbolt/bbolt.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
 
+	"github.com/go-stack/stack"
 	"go.etcd.io/bbolt"
 )
 
@@ -62,7 +63,7 @@ func (c *Cache) Configuration() *options.Options {
 
 // Connect instantiates the Cache mutex map and starts the Expired Entry Reaper goroutine
 func (c *Cache) Connect() error {
-	tl.Info(c.Logger, "bbolt cache setup", tl.Pairs{"name": c.Name, "cacheFile": c.Config.BBolt.Filename})
+	tl.Info(c.Logger, stack.Caller(0), "bbolt cache setup", tl.Pairs{"name": c.Name, "cacheFile": c.Config.BBolt.Filename})
 
 	c.lockPrefix = c.Name + ".bbolt."
 
@@ -98,7 +99,7 @@ func (c *Cache) Store(cacheKey string, data []byte, ttl time.Duration) error {
 func (c *Cache) storeNoIndex(cacheKey string, data []byte) {
 	err := c.store(cacheKey, data, 31536000*time.Second, false)
 	if err != nil {
-		tl.Error(c.Logger, "cache failed to write non-indexed object",
+		tl.Error(c.Logger, stack.Caller(0), "cache failed to write non-indexed object",
 			tl.Pairs{"cacheName": c.Name, "cacheProvider": "bbolt",
 				"cacheKey": cacheKey, "objectSize": len(data)})
 	}
@@ -115,7 +116,7 @@ func (c *Cache) store(cacheKey string, data []byte, ttl time.Duration, updateInd
 	if err != nil {
 		return err
 	}
-	tl.Debug(c.Logger, "bbolt cache store", tl.Pairs{"key": cacheKey, "ttl": ttl, "indexed": updateIndex})
+	tl.Debug(c.Logger, stack.Caller(0), "bbolt cache store", tl.Pairs{"key": cacheKey, "ttl": ttl, "indexed": updateIndex})
 	if updateIndex {
 		c.Index.UpdateObject(o)
 	}
@@ -145,7 +146,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool,
 		b := tx.Bucket([]byte(c.Config.BBolt.Bucket))
 		data = b.Get([]byte(cacheKey))
 		if data == nil {
-			tl.Debug(c.Logger, "bbolt cache miss", tl.Pairs{"key": cacheKey})
+			tl.Debug(c.Logger, stack.Caller(0), "bbolt cache miss", tl.Pairs{"key": cacheKey})
 			metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.Provider)
 			return cache.ErrKNF
 		}
@@ -172,7 +173,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool,
 	o.Expiration = c.Index.GetExpiration(cacheKey)
 
 	if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
-		tl.Debug(c.Logger, "bbolt cache retrieve", tl.Pairs{"cacheKey": cacheKey})
+		tl.Debug(c.Logger, stack.Caller(0), "bbolt cache retrieve", tl.Pairs{"cacheKey": cacheKey})
 		if atime {
 			go c.Index.UpdateObjectAccessTime(cacheKey)
 		}
@@ -203,7 +204,7 @@ func (c *Cache) remove(cacheKey string, isBulk bool) error {
 	})
 	nl.Release()
 	if err != nil {
-		tl.Error(c.Logger, "bbolt cache key delete failure",
+		tl.Error(c.Logger, stack.Caller(0), "bbolt cache key delete failure",
 			tl.Pairs{"cacheKey": cacheKey, "reason": err.Error()})
 		return err
 	}
@@ -211,7 +212,7 @@ func (c *Cache) remove(cacheKey string, isBulk bool) error {
 		go c.Index.RemoveObject(cacheKey)
 	}
 	metrics.ObserveCacheDel(c.Name, c.Config.Provider, 0)
-	tl.Debug(c.Logger, "bbolt cache key delete", tl.Pairs{"key": cacheKey})
+	tl.Debug(c.Logger, stack.Caller(0), "bbolt cache key delete", tl.Pairs{"key": cacheKey})
 	return nil
 }
 

--- a/pkg/cache/filesystem/filesystem.go
+++ b/pkg/cache/filesystem/filesystem.go
@@ -33,6 +33,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
 	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
+
+	"github.com/go-stack/stack"
 )
 
 // Cache describes a Filesystem Cache
@@ -62,7 +64,7 @@ func (c *Cache) Configuration() *options.Options {
 
 // Connect instantiates the Cache mutex map and starts the Expired Entry Reaper goroutine
 func (c *Cache) Connect() error {
-	tl.Info(c.Logger, "filesystem cache setup", tl.Pairs{"name": c.Name,
+	tl.Info(c.Logger, stack.Caller(0), "filesystem cache setup", tl.Pairs{"name": c.Name,
 		"cachePath": c.Config.Filesystem.CachePath})
 	if err := makeDirectory(c.Config.Filesystem.CachePath); err != nil {
 		return err
@@ -84,8 +86,9 @@ func (c *Cache) Store(cacheKey string, data []byte, ttl time.Duration) error {
 func (c *Cache) storeNoIndex(cacheKey string, data []byte) {
 	err := c.store(cacheKey, data, 31536000*time.Second, false)
 	if err != nil {
-		tl.Error(c.Logger, "cache failed to write non-indexed object", tl.Pairs{"cacheName": c.Name,
-			"cacheProvider": "filesystem", "cacheKey": cacheKey, "objectSize": len(data)})
+		tl.Error(c.Logger, stack.Caller(0),
+			"cache failed to write non-indexed object", tl.Pairs{"cacheName": c.Name,
+				"cacheProvider": "filesystem", "cacheKey": cacheKey, "objectSize": len(data)})
 	}
 }
 
@@ -111,7 +114,7 @@ func (c *Cache) store(cacheKey string, data []byte, ttl time.Duration, updateInd
 		nl.Release()
 		return err
 	}
-	tl.Debug(c.Logger, "filesystem cache store",
+	tl.Debug(c.Logger, stack.Caller(0), "filesystem cache store",
 		tl.Pairs{"key": cacheKey, "dataFile": dataFile, "indexed": updateIndex})
 	if updateIndex {
 		c.Index.UpdateObject(o)
@@ -134,7 +137,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) ([]byte
 	nl.RRelease()
 
 	if err != nil {
-		tl.Debug(c.Logger, "filesystem cache miss", tl.Pairs{"key": cacheKey, "dataFile": dataFile})
+		tl.Debug(c.Logger, stack.Caller(0), "filesystem cache miss", tl.Pairs{"key": cacheKey, "dataFile": dataFile})
 		metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.Provider)
 		return nil, status.LookupStatusKeyMiss, cache.ErrKNF
 	}
@@ -155,7 +158,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) ([]byte
 
 	o.Expiration = c.Index.GetExpiration(cacheKey)
 	if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
-		tl.Debug(c.Logger, "filesystem cache retrieve", tl.Pairs{"key": cacheKey, "dataFile": dataFile})
+		tl.Debug(c.Logger, stack.Caller(0), "filesystem cache retrieve", tl.Pairs{"key": cacheKey, "dataFile": dataFile})
 		if atime {
 			go c.Index.UpdateObjectAccessTime(cacheKey)
 		}

--- a/pkg/cache/index/index.go
+++ b/pkg/cache/index/index.go
@@ -28,6 +28,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache/metrics"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
 	gm "github.com/tricksterproxy/trickster/pkg/util/metrics"
+
+	"github.com/go-stack/stack"
 )
 
 //go:generate msgp
@@ -126,7 +128,7 @@ func NewIndex(cacheName, cacheProvider string, indexData []byte, o *options.Opti
 		if o.FlushInterval > 0 {
 			go i.flusher(logger)
 		} else {
-			tl.Warn(logger, "cache index flusher did not start",
+			tl.Warn(logger, stack.Caller(0), "cache index flusher did not start",
 				tl.Pairs{"cacheName": i.name, "flushInterval": o.FlushInterval})
 		}
 	}
@@ -134,7 +136,7 @@ func NewIndex(cacheName, cacheProvider string, indexData []byte, o *options.Opti
 	if o.ReapInterval > 0 {
 		go i.reaper(logger)
 	} else {
-		tl.Warn(logger, "cache reaper did not start",
+		tl.Warn(logger, stack.Caller(0), "cache reaper did not start",
 			tl.Pairs{"cacheName": i.name, "reapInterval": o.ReapInterval})
 	}
 
@@ -270,7 +272,7 @@ func (idx *Index) flushOnce(logger interface{}) {
 	bytes, err := idx.MarshalMsg(nil)
 	idx.mtx.Unlock()
 	if err != nil {
-		tl.Warn(logger, "unable to serialize index for flushing",
+		tl.Warn(logger, stack.Caller(0), "unable to serialize index for flushing",
 			tl.Pairs{"cacheName": idx.name, "detail": err.Error()})
 		return
 	}
@@ -333,7 +335,8 @@ func (idx *Index) reap(logger interface{}) {
 			return
 		}
 
-		tl.Debug(logger, "max cache size reached. evicting least-recently-accessed records",
+		tl.Debug(logger, stack.Caller(0),
+			"max cache size reached. evicting least-recently-accessed records",
 			tl.Pairs{
 				"reason":         evictionType,
 				"cacheSizeBytes": idx.CacheSize, "maxSizeBytes": idx.options.MaxSizeBytes,
@@ -379,7 +382,7 @@ func (idx *Index) reap(logger interface{}) {
 			cacheChanged = true
 		}
 
-		tl.Debug(logger, "size-based cache eviction exercise completed",
+		tl.Debug(logger, stack.Caller(0), "size-based cache eviction exercise completed",
 			tl.Pairs{
 				"reason":         evictionType,
 				"cacheSizeBytes": idx.CacheSize, "maxSizeBytes": idx.options.MaxSizeBytes,

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -29,6 +29,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
 	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
+
+	"github.com/go-stack/stack"
 )
 
 // Cache defines a a Memory Cache client that conforms to the Cache interface
@@ -59,7 +61,7 @@ func (c *Cache) Configuration() *options.Options {
 
 // Connect initializes the Cache
 func (c *Cache) Connect() error {
-	tl.Info(c.Logger, "memorycache setup", tl.Pairs{"name": c.Name,
+	tl.Info(c.Logger, stack.Caller(0), "memorycache setup", tl.Pairs{"name": c.Name,
 		"maxSizeBytes": c.Config.Index.MaxSizeBytes, "maxSizeObjects": c.Config.Index.MaxSizeObjects})
 	c.lockPrefix = c.Name + ".memory."
 	c.client = sync.Map{}
@@ -96,7 +98,7 @@ func (c *Cache) store(cacheKey string, byteData []byte, refData cache.ReferenceO
 
 	if o1 != nil && o2 != nil {
 		nl, _ := c.locker.Acquire(c.lockPrefix + cacheKey)
-		tl.Debug(c.Logger, "memorycache cache store",
+		tl.Debug(c.Logger, stack.Caller(0), "memorycache cache store",
 			tl.Pairs{"cacheKey": cacheKey, "length": l, "ttl": ttl, "is_direct": isDirect})
 		c.client.Store(cacheKey, o1)
 		if updateIndex {
@@ -145,7 +147,7 @@ func (c *Cache) retrieve(cacheKey string, allowExpired bool, atime bool) (*index
 		o.Expiration = c.Index.GetExpiration(cacheKey)
 
 		if allowExpired || o.Expiration.IsZero() || o.Expiration.After(time.Now()) {
-			tl.Debug(c.Logger, "memory cache retrieve", tl.Pairs{"cacheKey": cacheKey})
+			tl.Debug(c.Logger, stack.Caller(0), "memory cache retrieve", tl.Pairs{"cacheKey": cacheKey})
 			if atime {
 				go c.Index.UpdateObjectAccessTime(cacheKey)
 			}

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -21,14 +21,15 @@ package redis
 import (
 	"time"
 
-	"github.com/go-redis/redis"
-
 	"github.com/tricksterproxy/trickster/pkg/cache"
 	"github.com/tricksterproxy/trickster/pkg/cache/metrics"
 	"github.com/tricksterproxy/trickster/pkg/cache/options"
 	"github.com/tricksterproxy/trickster/pkg/cache/status"
 	"github.com/tricksterproxy/trickster/pkg/locks"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
+
+	"github.com/go-redis/redis"
+	"github.com/go-stack/stack"
 )
 
 // Redis is the string "redis"
@@ -62,7 +63,7 @@ func (c *Cache) Configuration() *options.Options {
 
 // Connect connects to the configured Redis endpoint
 func (c *Cache) Connect() error {
-	tl.Info(c.Logger, "connecting to redis",
+	tl.Info(c.Logger, stack.Caller(0), "connecting to redis",
 		tl.Pairs{"protocol": c.Config.Redis.Protocol, "Endpoint": c.Config.Redis.Endpoint})
 
 	switch c.Config.Redis.ClientType {
@@ -97,7 +98,7 @@ func (c *Cache) Connect() error {
 // Store places the the data into the Redis Cache using the provided Key and TTL
 func (c *Cache) Store(cacheKey string, data []byte, ttl time.Duration) error {
 	metrics.ObserveCacheOperation(c.Name, c.Config.Provider, "set", "none", float64(len(data)))
-	tl.Debug(c.Logger, "redis cache store", tl.Pairs{"key": cacheKey})
+	tl.Debug(c.Logger, stack.Caller(0), "redis cache store", tl.Pairs{"key": cacheKey})
 	return c.client.Set(cacheKey, data, ttl).Err()
 }
 
@@ -108,25 +109,25 @@ func (c *Cache) Retrieve(cacheKey string, allowExpired bool) ([]byte, status.Loo
 
 	if err == nil {
 		data := []byte(res)
-		tl.Debug(c.Logger, "redis cache retrieve", tl.Pairs{"key": cacheKey})
+		tl.Debug(c.Logger, stack.Caller(0), "redis cache retrieve", tl.Pairs{"key": cacheKey})
 		metrics.ObserveCacheOperation(c.Name, c.Config.Provider, "get", "hit", float64(len(data)))
 		return data, status.LookupStatusHit, nil
 	}
 
 	if err == redis.Nil {
-		tl.Debug(c.Logger, "redis cache miss", tl.Pairs{"key": cacheKey})
+		tl.Debug(c.Logger, stack.Caller(0), "redis cache miss", tl.Pairs{"key": cacheKey})
 		metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.Provider)
 		return nil, status.LookupStatusKeyMiss, cache.ErrKNF
 	}
 
-	tl.Debug(c.Logger, "redis cache retrieve failed", tl.Pairs{"key": cacheKey, "reason": err.Error()})
+	tl.Debug(c.Logger, stack.Caller(0), "redis cache retrieve failed", tl.Pairs{"key": cacheKey, "reason": err.Error()})
 	metrics.ObserveCacheMiss(cacheKey, c.Name, c.Config.Provider)
 	return nil, status.LookupStatusError, err
 }
 
 // Remove removes an object in cache, if present
 func (c *Cache) Remove(cacheKey string) {
-	tl.Debug(c.Logger, "redis cache remove", tl.Pairs{"key": cacheKey})
+	tl.Debug(c.Logger, stack.Caller(0), "redis cache remove", tl.Pairs{"key": cacheKey})
 	c.client.Del(cacheKey)
 	metrics.ObserveCacheDel(c.Name, c.Config.Provider, 0)
 }
@@ -138,14 +139,14 @@ func (c *Cache) SetTTL(cacheKey string, ttl time.Duration) {
 
 // BulkRemove removes a list of objects from the cache. noLock is not used for Redis
 func (c *Cache) BulkRemove(cacheKeys []string) {
-	tl.Debug(c.Logger, "redis cache bulk remove", tl.Pairs{})
+	tl.Debug(c.Logger, stack.Caller(0), "redis cache bulk remove", tl.Pairs{})
 	c.client.Del(cacheKeys...)
 	metrics.ObserveCacheDel(c.Name, c.Config.Provider, float64(len(cacheKeys)))
 }
 
 // Close disconnects from the Redis Cache
 func (c *Cache) Close() error {
-	tl.Info(c.Logger, "closing redis connection", tl.Pairs{})
+	tl.Info(c.Logger, stack.Caller(0), "closing redis connection", tl.Pairs{})
 	return c.closer()
 }
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -50,10 +50,11 @@ type SyncLogger struct {
 	*Logger
 }
 
-func Debug(logger interface{}, event string, detail Pairs) {
+func Debug(logger interface{}, caller stack.Call, event string, detail Pairs) {
 	if logger == nil {
 		return
 	}
+	detail["caller"] = pkgCaller{caller}
 	switch logger.(type) {
 	case *Logger:
 		go logger.(*Logger).Debug(event, detail)
@@ -66,10 +67,11 @@ func Debug(logger interface{}, event string, detail Pairs) {
 	}
 }
 
-func Info(logger interface{}, event string, detail Pairs) {
+func Info(logger interface{}, caller stack.Call, event string, detail Pairs) {
 	if logger == nil {
 		return
 	}
+	detail["caller"] = pkgCaller{caller}
 	switch logger.(type) {
 	case *Logger:
 		go logger.(*Logger).Info(event, detail)
@@ -82,10 +84,11 @@ func Info(logger interface{}, event string, detail Pairs) {
 	}
 }
 
-func Warn(logger interface{}, event string, detail Pairs) {
+func Warn(logger interface{}, caller stack.Call, event string, detail Pairs) {
 	if logger == nil {
 		return
 	}
+	detail["caller"] = pkgCaller{caller}
 	switch logger.(type) {
 	case *Logger:
 		go logger.(*Logger).Warn(event, detail)
@@ -98,10 +101,11 @@ func Warn(logger interface{}, event string, detail Pairs) {
 	}
 }
 
-func WarnOnce(logger interface{}, key string, event string, detail Pairs) {
+func WarnOnce(logger interface{}, caller stack.Call, key string, event string, detail Pairs) {
 	if logger == nil {
 		return
 	}
+	detail["caller"] = pkgCaller{caller}
 	switch logger.(type) {
 	case *Logger: // must  be Synchronous to avoid double writes
 		logger.(*Logger).WarnOnce(key, event, detail)
@@ -114,10 +118,11 @@ func WarnOnce(logger interface{}, key string, event string, detail Pairs) {
 	}
 }
 
-func Error(logger interface{}, event string, detail Pairs) {
+func Error(logger interface{}, caller stack.Call, event string, detail Pairs) {
 	if logger == nil {
 		return
 	}
+	detail["caller"] = pkgCaller{caller}
 	switch logger.(type) {
 	case *Logger:
 		go logger.(*Logger).Error(event, detail)
@@ -131,9 +136,10 @@ func Error(logger interface{}, event string, detail Pairs) {
 }
 
 // Fatal sends a "FATAL" event to the Logger and exits the program with the provided exit code
-func Fatal(logger interface{}, code int, event string, detail Pairs) {
+func Fatal(logger interface{}, caller stack.Call, code int, event string, detail Pairs) {
 	// go-kit/log/level does not support Fatal, so implemented separately here
 	detail["level"] = "fatal"
+	detail["caller"] = pkgCaller{caller}
 	switch logger.(type) {
 	case *Logger:
 		logger.(*Logger).Fatal(code, event, detail)
@@ -192,9 +198,6 @@ func ConsoleLogger(logLevel string) *Logger {
 	l.baseLogger = gkl.With(l.baseLogger,
 		"time", gkl.DefaultTimestampUTC,
 		"app", "trickster",
-		"caller", gkl.Valuer(func() interface{} {
-			return pkgCaller{stack.Caller(6)}
-		}),
 	)
 	l.SetLogLevel(logLevel)
 	return l
@@ -251,9 +254,6 @@ func New(conf *config.Config) *Logger {
 	l.baseLogger = gkl.With(l.baseLogger,
 		"time", gkl.DefaultTimestampUTC,
 		"app", "trickster",
-		"caller", gkl.Valuer(func() interface{} {
-			return pkgCaller{stack.Caller(6)}
-		}),
 	)
 
 	l.SetLogLevel(conf.Logging.LogLevel)

--- a/pkg/logging/logging_test.go
+++ b/pkg/logging/logging_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	"github.com/tricksterproxy/trickster/pkg/config"
+
+	"github.com/go-stack/stack"
 )
 
 func TestConsoleLogger(t *testing.T) {
@@ -63,7 +65,7 @@ func TestNewLogger_LogFile(t *testing.T) {
 	conf.Main = &config.MainConfig{InstanceID: 1}
 	conf.Logging = &config.LoggingConfig{LogFile: fileName, LogLevel: "info"}
 	log := &SyncLogger{Logger: New(conf)}
-	Info(log, "test entry", Pairs{"testKey": "testVal"})
+	Info(log, stack.Caller(0), "test entry", Pairs{"testKey": "testVal"})
 	if _, err := os.Stat(instanceFileName); err != nil {
 		t.Errorf(err.Error())
 	}

--- a/pkg/proxy/engines/access_logs.go
+++ b/pkg/proxy/engines/access_logs.go
@@ -20,11 +20,13 @@ import (
 	"net/http"
 
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
+
+	"github.com/go-stack/stack"
 )
 
 func logUpstreamRequest(logger interface{}, backendName, backendProvider, handlerName, method,
 	path, userAgent string, responseCode, size int, requestDuration float64) {
-	tl.Debug(logger, "upstream request",
+	tl.Debug(logger, stack.Caller(0), "upstream request",
 		tl.Pairs{
 			"backendName":     backendName,
 			"backendProvider": backendProvider,
@@ -39,7 +41,7 @@ func logUpstreamRequest(logger interface{}, backendName, backendProvider, handle
 }
 
 func logDownstreamRequest(logger interface{}, r *http.Request) {
-	tl.Debug(logger, "downtream request",
+	tl.Debug(logger, stack.Caller(0), "downtream request",
 		tl.Pairs{
 			"uri":       r.RequestURI,
 			"method":    r.Method,

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -32,6 +32,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/proxy/request"
 	tspan "github.com/tricksterproxy/trickster/pkg/tracing/span"
 
+	"github.com/go-stack/stack"
 	"github.com/golang/snappy"
 	"go.opentelemetry.io/otel/label"
 )
@@ -99,7 +100,7 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 		}
 
 		if inflate {
-			tl.Debug(rsc.Logger, "decompressing cached data", tl.Pairs{"cacheKey": key})
+			tl.Debug(rsc.Logger, stack.Caller(0), "decompressing cached data", tl.Pairs{"cacheKey": key})
 			b, err := snappy.Decode(nil, bytes)
 			if err == nil {
 				bytes = b
@@ -107,7 +108,7 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 		}
 		_, err = d.UnmarshalMsg(bytes)
 		if err != nil {
-			tl.Error(rsc.Logger, "error unmarshaling cache document", tl.Pairs{
+			tl.Error(rsc.Logger, stack.Caller(0), "error unmarshaling cache document", tl.Pairs{
 				"cacheKey": key,
 				"detail":   err.Error(),
 			})
@@ -210,14 +211,14 @@ func WriteCache(ctx context.Context, c cache.Cache, key string, d *HTTPDocument,
 	// for non-memory, we have to seralize the document to a byte slice to store
 	bytes, err = d.MarshalMsg(nil)
 	if err != nil {
-		tl.Error(rsc.Logger, "error marshaling cache document", tl.Pairs{
+		tl.Error(rsc.Logger, stack.Caller(0), "error marshaling cache document", tl.Pairs{
 			"cacheKey": key,
 			"detail":   err.Error(),
 		})
 	}
 
 	if compress {
-		tl.Debug(rsc.Logger, "compressing cache data", tl.Pairs{"cacheKey": key})
+		tl.Debug(rsc.Logger, stack.Caller(0), "compressing cache data", tl.Pairs{"cacheKey": key})
 		bytes = append([]byte{1}, snappy.Encode(nil, bytes)...)
 	} else {
 		bytes = append([]byte{0}, bytes...)

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -30,6 +30,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
 	"github.com/tricksterproxy/trickster/pkg/proxy/ranges/byterange"
 	"github.com/tricksterproxy/trickster/pkg/timeseries"
+
+	"github.com/go-stack/stack"
 )
 
 //go:generate msgp
@@ -165,7 +167,7 @@ func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response, body []byte,
 			d.RangeParts.Compress()
 			d.Ranges = d.RangeParts.Ranges()
 		} else {
-			tl.Error(logger, "unable to parse multipart range response body", tl.Pairs{"detail": err.Error})
+			tl.Error(logger, stack.Caller(0), "unable to parse multipart range response body", tl.Pairs{"detail": err.Error})
 		}
 	} else {
 		if !strings.HasPrefix(ct, headers.ValueMultipartByteRanges) {

--- a/pkg/proxy/engines/httpproxy.go
+++ b/pkg/proxy/engines/httpproxy.go
@@ -39,6 +39,7 @@ import (
 	tspan "github.com/tricksterproxy/trickster/pkg/tracing/span"
 	"github.com/tricksterproxy/trickster/pkg/util/metrics"
 
+	"github.com/go-stack/stack"
 	othttptrace "go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/otel/label"
 )
@@ -180,7 +181,8 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 
 	resp, err := oc.HTTPClient.Do(r)
 	if err != nil {
-		tl.Error(rsc.Logger, "error downloading url", tl.Pairs{"url": r.URL.String(), "detail": err.Error()})
+		tl.Error(rsc.Logger, stack.Caller(0),
+			"error downloading url", tl.Pairs{"url": r.URL.String(), "detail": err.Error()})
 		// if there is an err and the response is nil, the server could not be reached
 		// so make a 502 for the downstream response
 		if resp == nil {
@@ -217,7 +219,7 @@ func PrepareFetchReader(r *http.Request) (io.ReadCloser, *http.Response, int64) 
 		d, err := http.ParseTime(date)
 		if err == nil {
 			if offset := time.Since(d); time.Duration(math.Abs(float64(offset))) > time.Minute {
-				tl.WarnOnce(rsc.Logger, "clockoffset."+oc.Name,
+				tl.WarnOnce(rsc.Logger, stack.Caller(0), "clockoffset."+oc.Name,
 					"clock offset between trickster host and origin is high and may cause data anomalies",
 					tl.Pairs{
 						"backendName":   oc.Name,

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -33,6 +33,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/proxy/request"
 	tspan "github.com/tricksterproxy/trickster/pkg/tracing/span"
 
+	"github.com/go-stack/stack"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 )
@@ -424,11 +425,12 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 		if f, ok := cacheResponseHandlers[pr.cacheStatus]; ok {
 			f(pr)
 		} else {
-			tl.Warn(pr.Logger, "unhandled cache lookup response", tl.Pairs{"lookupStatus": pr.cacheStatus})
+			tl.Warn(pr.Logger, stack.Caller(0),
+				"unhandled cache lookup response", tl.Pairs{"lookupStatus": pr.cacheStatus})
 			return nil, status.LookupStatusProxyOnly
 		}
 	} else {
-		tl.Error(pr.Logger, "cache lookup error", tl.Pairs{"detail": err.Error()})
+		tl.Error(pr.Logger, stack.Caller(0), "cache lookup error", tl.Pairs{"detail": err.Error()})
 		pr.cacheDocument = nil
 		pr.cacheStatus = status.LookupStatusKeyMiss
 		handleCacheKeyMiss(pr)

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/proxy/request"
 	tspan "github.com/tricksterproxy/trickster/pkg/tracing/span"
 
+	"github.com/go-stack/stack"
 	"go.opentelemetry.io/otel/api/trace"
 	"go.opentelemetry.io/otel/label"
 )
@@ -166,7 +167,7 @@ func (pr *proxyRequest) Fetch() ([]byte, *http.Response, time.Duration) {
 		resp.Body.Close()
 	}
 	if err != nil {
-		tl.Error(pr.Logger, "error reading body from http response",
+		tl.Error(pr.Logger, stack.Caller(0), "error reading body from http response",
 			tl.Pairs{"url": pr.URL.String(), "detail": err.Error()})
 		return []byte{}, resp, 0
 	}

--- a/pkg/proxy/handlers/reload.go
+++ b/pkg/proxy/handlers/reload.go
@@ -25,6 +25,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/config/reload"
 	tl "github.com/tricksterproxy/trickster/pkg/logging"
 	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
+
+	"github.com/go-stack/stack"
 )
 
 // ReloadHandleFunc will reload the running configuration if it has changed
@@ -36,7 +38,8 @@ func ReloadHandleFunc(f reload.ReloaderFunc, conf *config.Config, wg *sync.WaitG
 			conf.Main.ReloaderLock.Lock()
 			defer conf.Main.ReloaderLock.Unlock()
 			if conf.IsStale() {
-				tl.Warn(log, "configuration reload starting now", tl.Pairs{"source": "reloadEndpoint"})
+				tl.Warn(log, stack.Caller(0),
+					"configuration reload starting now", tl.Pairs{"source": "reloadEndpoint"})
 				err := f(conf, wg, log, caches, args, false)
 				if err == nil {
 					w.Header().Set(headers.NameContentType, headers.ValueTextPlain)

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -34,6 +34,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/util/metrics"
 	"golang.org/x/net/netutil"
 
+	"github.com/go-stack/stack"
 	"github.com/gorilla/handlers"
 )
 
@@ -141,7 +142,7 @@ func NewListener(listenAddress string, listenPort, connectionsLimit int,
 		metrics.ProxyMaxConnections.Set(float64(connectionsLimit))
 	}
 
-	tl.Debug(logger, "starting proxy listener", tl.Pairs{
+	tl.Debug(logger, stack.Caller(0), "starting proxy listener", tl.Pairs{
 		"connectionsLimit": connectionsLimit,
 		"scheme":           listenerType,
 		"address":          listenAddress,
@@ -183,13 +184,14 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 	var err error
 	l.Listener, err = NewListener(address, port, connectionsLimit, tlsConfig, drainTimeout, logger)
 	if err != nil {
-		tl.Error(logger, "http listener startup failed", tl.Pairs{"name": listenerName, "detail": err})
+		tl.Error(logger, stack.Caller(0),
+			"http listener startup failed", tl.Pairs{"name": listenerName, "detail": err})
 		if exitOnError {
 			os.Exit(1)
 		}
 		return err
 	}
-	tl.Info(logger, "http listener starting",
+	tl.Info(logger, stack.Caller(0), "http listener starting",
 		tl.Pairs{"name": listenerName, "port": port, "address": address})
 
 	lg.listenersLock.Lock()
@@ -213,7 +215,8 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 		l.server = svr
 		err = svr.Serve(l)
 		if err != nil {
-			tl.Error(logger, "https listener stopping", tl.Pairs{"name": listenerName, "detail": err})
+			tl.Error(logger, stack.Caller(0),
+				"https listener stopping", tl.Pairs{"name": listenerName, "detail": err})
 			if l.exitOnError {
 				os.Exit(1)
 			}
@@ -227,7 +230,8 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 	l.server = svr
 	err = svr.Serve(l)
 	if err != nil {
-		tl.Error(logger, "http listener stopping", tl.Pairs{"name": listenerName, "detail": err})
+		tl.Error(logger, stack.Caller(0),
+			"http listener stopping", tl.Pairs{"name": listenerName, "detail": err})
 		if l.exitOnError {
 			os.Exit(1)
 		}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -47,12 +47,14 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/tracing"
 	"github.com/tricksterproxy/trickster/pkg/util/middleware"
 
+	"github.com/go-stack/stack"
 	"github.com/gorilla/mux"
 )
 
 // RegisterPprofRoutes will register the Pprof Debugging endpoints to the provided router
 func RegisterPprofRoutes(routerName string, h *http.ServeMux, logger interface{}) {
-	tl.Info(logger, "registering pprof /debug routes", tl.Pairs{"routerName": routerName})
+	tl.Info(logger, stack.Caller(0),
+		"registering pprof /debug routes", tl.Pairs{"routerName": routerName})
 	h.HandleFunc("/debug/pprof/", pprof.Index)
 	h.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	h.HandleFunc("/debug/pprof/profile", pprof.Profile)
@@ -92,7 +94,7 @@ func RegisterProxyRoutes(conf *config.Config, router *mux.Router,
 					fmt.Errorf("only one backend can be marked as default. Found both %s and %s",
 						defaultBackend, k)
 			}
-			tl.Debug(logger, "default backend identified", tl.Pairs{"name": k})
+			tl.Debug(logger, stack.Caller(0), "default backend identified", tl.Pairs{"name": k})
 			defaultBackend = k
 			cdo = o
 			continue
@@ -149,7 +151,7 @@ func registerBackendRoutes(router *mux.Router, conf *config.Config, k string,
 	}
 
 	if !dryRun {
-		tl.Info(logger, "registering route paths", tl.Pairs{"backendName": k,
+		tl.Info(logger, stack.Caller(0), "registering route paths", tl.Pairs{"backendName": k,
 			"backendProvider": o.Provider, "upstreamHost": o.Host})
 	}
 
@@ -228,7 +230,7 @@ func RegisterPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 	if h, ok := handlers["health"]; ok &&
 		oo.HealthCheckUpstreamPath != "" && oo.HealthCheckVerb != "" && healthHandlerPath != "" {
 		hp := strings.Replace(healthHandlerPath+"/"+oo.Name, "//", "/", -1)
-		tl.Debug(logger, "registering health handler path",
+		tl.Debug(logger, stack.Caller(0), "registering health handler path",
 			tl.Pairs{"path": hp, "backendName": oo.Name,
 				"upstreamPath": oo.HealthCheckUpstreamPath,
 				"upstreamVerb": oo.HealthCheckVerb})
@@ -269,7 +271,7 @@ func RegisterPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 			p.Handler = h
 			plist = append(plist, k)
 		} else {
-			tl.Info(logger, "invalid handler name for path",
+			tl.Info(logger, stack.Caller(0), "invalid handler name for path",
 				tl.Pairs{"path": p.Path, "handlerName": p.HandlerName})
 			deletes = append(deletes, p.Path)
 		}
@@ -292,7 +294,7 @@ func RegisterPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 		pathPrefix := "/" + oo.Name
 		handledPath := pathPrefix + p.Path
 
-		tl.Debug(logger, "registering backend handler path",
+		tl.Debug(logger, stack.Caller(0), "registering backend handler path",
 			tl.Pairs{"backendName": oo.Name, "path": v, "handlerName": p.HandlerName,
 				"originHost": oo.Host, "handledPath": handledPath, "matchType": p.MatchType,
 				"frontendHosts": strings.Join(oo.Hosts, ",")})
@@ -311,7 +313,8 @@ func RegisterPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 				}
 				if !oo.PathRoutingDisabled {
 					// Path Routing
-					router.PathPrefix(handledPath).Handler(middleware.StripPathPrefix(pathPrefix, decorate(p))).Methods(p.Methods...)
+					router.PathPrefix(handledPath).Handler(middleware.StripPathPrefix(pathPrefix,
+						decorate(p))).Methods(p.Methods...)
 				}
 				or.PathPrefix(p.Path).Handler(decorate(p)).Methods(p.Methods...)
 			default:
@@ -322,7 +325,8 @@ func RegisterPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 				}
 				if !oo.PathRoutingDisabled {
 					// Path Routing
-					router.Handle(handledPath, middleware.StripPathPrefix(pathPrefix, decorate(p))).Methods(p.Methods...)
+					router.Handle(handledPath, middleware.StripPathPrefix(pathPrefix,
+						decorate(p))).Methods(p.Methods...)
 				}
 				or.Handle(p.Path, decorate(p)).Methods(p.Methods...)
 			}
@@ -330,11 +334,12 @@ func RegisterPathRoutes(router *mux.Router, handlers map[string]http.Handler,
 	}
 
 	if oo.IsDefault {
-		tl.Info(logger, "registering default backend handler paths", tl.Pairs{"backendName": oo.Name})
+		tl.Info(logger, stack.Caller(0),
+			"registering default backend handler paths", tl.Pairs{"backendName": oo.Name})
 		for _, v := range plist {
 			p := pathsWithVerbs[v]
 			if p.Handler != nil && len(p.Methods) > 0 {
-				tl.Debug(logger, "registering default backend handler paths",
+				tl.Debug(logger, stack.Caller(0), "registering default backend handler paths",
 					tl.Pairs{"backendName": oo.Name, "path": p.Path, "handlerName": p.HandlerName,
 						"matchType": p.MatchType})
 				switch p.MatchType {

--- a/pkg/tracing/registration/registration.go
+++ b/pkg/tracing/registration/registration.go
@@ -88,7 +88,7 @@ func RegisterAll(cfg *config.Config, logger interface{}, isDryRun bool) (tracing
 func GetTracer(options *options.Options, logger interface{}, isDryRun bool) (*tracing.Tracer, error) {
 
 	if options == nil {
-		tl.Info(logger, stack.Caller(0), "nil tracing config, using noop tracer", nil)
+		tl.Info(logger, stack.Caller(0), "nil tracing config, using noop tracer", tl.Pairs{})
 		return noop.NewTracer(options)
 	}
 

--- a/pkg/tracing/registration/registration.go
+++ b/pkg/tracing/registration/registration.go
@@ -31,6 +31,8 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/tracing/options"
 	"github.com/tricksterproxy/trickster/pkg/tracing/providers"
 	"github.com/tricksterproxy/trickster/pkg/util/strings"
+
+	"github.com/go-stack/stack"
 )
 
 // RegisterAll registers all Tracers in the provided configuration, and returns
@@ -86,7 +88,7 @@ func RegisterAll(cfg *config.Config, logger interface{}, isDryRun bool) (tracing
 func GetTracer(options *options.Options, logger interface{}, isDryRun bool) (*tracing.Tracer, error) {
 
 	if options == nil {
-		tl.Info(logger, "nil tracing config, using noop tracer", nil)
+		tl.Info(logger, stack.Caller(0), "nil tracing config, using noop tracer", nil)
 		return noop.NewTracer(options)
 	}
 
@@ -94,7 +96,7 @@ func GetTracer(options *options.Options, logger interface{}, isDryRun bool) (*tr
 		if isDryRun {
 			return
 		}
-		tl.Info(logger,
+		tl.Info(logger, stack.Caller(0),
 			"tracer registration",
 			tl.Pairs{
 				"name":         options.Name,


### PR DESCRIPTION
this fixes an issue where the `caller` field in a 2.0 log was never accurate; with this change, it is 100% of the time. the meat of this change is in logging.go (requiring the caller to pass in it's stack.Call for Debug, Info, Warn, etc. All other files changed are solely for conforming to the updated logging function prototypes.