### PR TITLE
2.0 basic proxy

### DIFF
--- a/pkg/backends/providers/providers.go
+++ b/pkg/backends/providers/providers.go
@@ -22,29 +22,29 @@ import "strconv"
 type Provider int
 
 const (
-	// ProviderRPC represents thee Reverse Proxy Cache backend provider
-	ProviderRPC = Provider(iota)
-	// ProviderRule represents the Ruler backend provider
-	ProviderRule
-	// ProviderPrometheus represents the Prometheus backend provider
-	ProviderPrometheus
-	// ProviderInfluxDB represents the InfluxDB backend provider
-	ProviderInfluxDB
-	// ProviderIronDB represents the IRONdb backend provider
-	ProviderIronDB
-	// ProviderClickHouse represents the ClickHouse backend provider
-	ProviderClickHouse
+	// RPC represents thee Reverse Proxy Cache backend provider
+	RPC = Provider(iota)
+	// Rule represents the Ruler backend provider
+	Rule
+	// Prometheus represents the Prometheus backend provider
+	Prometheus
+	// InfluxDB represents the InfluxDB backend provider
+	InfluxDB
+	// IronDB represents the IRONdb backend provider
+	IronDB
+	// ClickHouse represents the ClickHouse backend provider
+	ClickHouse
 )
 
 // Names is a map of Providers keyed by string name
 var Names = map[string]Provider{
-	"rule":              ProviderRule,
-	"reverseproxycache": ProviderRPC,
-	"rpc":               ProviderRPC,
-	"prometheus":        ProviderPrometheus,
-	"influxdb":          ProviderInfluxDB,
-	"irondb":            ProviderIronDB,
-	"clickhouse":        ProviderClickHouse,
+	"rule":              Rule,
+	"reverseproxycache": RPC,
+	"rpc":               RPC,
+	"prometheus":        Prometheus,
+	"influxdb":          InfluxDB,
+	"irondb":            IronDB,
+	"clickhouse":        ClickHouse,
 }
 
 // Values is a map of Providers valued by string name
@@ -55,7 +55,7 @@ func init() {
 		Values[v] = k
 	}
 	// ensure consistent reverse mapping for reverseproxycache as rpc
-	Values[ProviderRPC] = "rpc"
+	Values[RPC] = "rpc"
 }
 
 func (t Provider) String() string {

--- a/pkg/backends/providers/providers.go
+++ b/pkg/backends/providers/providers.go
@@ -22,8 +22,10 @@ import "strconv"
 type Provider int
 
 const (
-	// RPC represents thee Reverse Proxy Cache backend provider
+	// RPC represents the Reverse Proxy Cache backend provider
 	RPC = Provider(iota)
+	// RP represents the Reverse Proxy (no caching) backend provider
+	RP
 	// Rule represents the Ruler backend provider
 	Rule
 	// Prometheus represents the Prometheus backend provider
@@ -45,6 +47,9 @@ var Names = map[string]Provider{
 	"influxdb":          InfluxDB,
 	"irondb":            IronDB,
 	"clickhouse":        ClickHouse,
+	"proxy":             RP,
+	"reverseproxy":      RP,
+	"rp":                RP,
 }
 
 // Values is a map of Providers valued by string name
@@ -55,7 +60,9 @@ func init() {
 		Values[v] = k
 	}
 	// ensure consistent reverse mapping for reverseproxycache as rpc
+	// and "rp" for proxy
 	Values[RPC] = "rpc"
+	Values[RP] = "rp"
 }
 
 func (t Provider) String() string {

--- a/pkg/backends/providers/providers_test.go
+++ b/pkg/backends/providers/providers_test.go
@@ -23,8 +23,8 @@ import (
 
 func TestProviderString(t *testing.T) {
 
-	t1 := ProviderRPC
-	t2 := ProviderPrometheus
+	t1 := RPC
+	t2 := Prometheus
 	var t3 Provider = 13
 
 	if t1.String() != "rpc" {

--- a/pkg/backends/reverseproxy/handler_health.go
+++ b/pkg/backends/reverseproxy/handler_health.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"context"
+	"net/http"
+
+	tctx "github.com/tricksterproxy/trickster/pkg/proxy/context"
+	"github.com/tricksterproxy/trickster/pkg/proxy/engines"
+	"github.com/tricksterproxy/trickster/pkg/proxy/headers"
+	"github.com/tricksterproxy/trickster/pkg/proxy/request"
+	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
+)
+
+// HealthHandler checks the health of the Configured Upstream Origin
+func (c *Client) HealthHandler(w http.ResponseWriter, r *http.Request) {
+
+	if c.healthURL == nil {
+		c.populateHeathCheckRequestValues()
+	}
+
+	if c.healthMethod == "-" {
+		w.WriteHeader(400)
+		w.Write([]byte("Health Check URL not Configured for backend: " + c.config.Name))
+		return
+	}
+
+	req, _ := http.NewRequest(c.healthMethod, c.healthURL.String(), nil)
+	rsc := request.GetResources(r)
+	req = req.WithContext(tctx.WithHealthCheckFlag(tctx.WithResources(context.Background(), rsc), true))
+
+	req.Header = c.healthHeaders
+	engines.DoProxy(w, req, true)
+}
+
+func (c *Client) populateHeathCheckRequestValues() {
+
+	oc := c.config
+
+	if oc.HealthCheckUpstreamPath == "-" {
+		oc.HealthCheckUpstreamPath = "/"
+	}
+	if oc.HealthCheckVerb == "-" {
+		oc.HealthCheckVerb = http.MethodGet
+	}
+
+	c.healthURL = urls.Clone(c.baseUpstreamURL)
+	c.healthURL.Path += oc.HealthCheckUpstreamPath
+	c.healthURL.RawQuery = oc.HealthCheckQuery
+	c.healthMethod = oc.HealthCheckVerb
+
+	if oc.HealthCheckHeaders != nil {
+		c.healthHeaders = http.Header{}
+		headers.UpdateHeaders(c.healthHeaders, oc.HealthCheckHeaders)
+	}
+}

--- a/pkg/backends/reverseproxy/handler_health_test.go
+++ b/pkg/backends/reverseproxy/handler_health_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"io/ioutil"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/tricksterproxy/trickster/pkg/proxy/request"
+	tu "github.com/tricksterproxy/trickster/pkg/util/testing"
+)
+
+func TestHealthHandler(t *testing.T) {
+
+	client := &Client{name: "test"}
+	ts, w, r, hc, err := tu.NewTestInstance("", client.DefaultPathConfigs, 200, "{}", nil, "rpc", "/health", "debug")
+	rsc := request.GetResources(r)
+	rsc.BackendClient = client
+	client.config = rsc.BackendOptions
+	client.webClient = hc
+	client.config.HTTPClient = hc
+	client.baseUpstreamURL, _ = url.Parse(ts.URL)
+
+	if err != nil {
+		t.Error(err)
+	} else {
+		defer ts.Close()
+	}
+
+	client.healthURL = &url.URL{}
+	client.healthMethod = "-"
+	client.HealthHandler(w, r)
+	resp := w.Result()
+	if resp.StatusCode != 400 {
+		t.Errorf("Expected status: 400 got %d.", resp.StatusCode)
+	}
+
+	client.healthURL = nil
+	client.HealthHandler(w, r)
+	w = httptest.NewRecorder()
+	resp = w.Result()
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status: 200 got %d.", resp.StatusCode)
+	}
+
+}
+
+func TestHealthHandlerCustomPath(t *testing.T) {
+	client := &Client{name: "test"}
+	ts, w, r, hc, err := tu.NewTestInstance("../../../testdata/test.custom_health.conf",
+		client.DefaultPathConfigs, 200, "{}", nil, "rpc", "/health", "debug")
+	if err != nil {
+		t.Error(err)
+	} else {
+		defer ts.Close()
+	}
+
+	client.baseUpstreamURL, _ = url.Parse(ts.URL)
+
+	rsc := request.GetResources(r)
+	rsc.BackendClient = client
+	client.config = rsc.BackendOptions
+	client.webClient = hc
+	client.config.HTTPClient = hc
+
+	client.HealthHandler(w, r)
+	resp := w.Result()
+
+	// it should return 200 OK
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200 got %d.", resp.StatusCode)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if string(bodyBytes) != "{}" {
+		t.Errorf("expected '{}' got %s.", bodyBytes)
+	}
+
+}

--- a/pkg/backends/reverseproxy/handler_proxy.go
+++ b/pkg/backends/reverseproxy/handler_proxy.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"net/http"
+
+	"github.com/tricksterproxy/trickster/pkg/proxy/engines"
+	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
+)
+
+// ProxyHandler will proxy the inbound HTTP Request to the configured origin
+func (c *Client) ProxyHandler(w http.ResponseWriter, r *http.Request) {
+	r.URL = urls.BuildUpstreamURL(r, c.baseUpstreamURL)
+	engines.DoProxy(w, r, true)
+}

--- a/pkg/backends/reverseproxy/handler_proxy_test.go
+++ b/pkg/backends/reverseproxy/handler_proxy_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/tricksterproxy/trickster/pkg/proxy/request"
+	tu "github.com/tricksterproxy/trickster/pkg/util/testing"
+)
+
+func TestProxyHandler(t *testing.T) {
+	client := &Client{name: "test"}
+	ts, w, r, hc, err := tu.NewTestInstance("", client.DefaultPathConfigs, 200, "{}", nil, "rpc", "/health", "debug")
+	rsc := request.GetResources(r)
+	rsc.BackendClient = client
+	client.config = rsc.BackendOptions
+	client.webClient = hc
+	client.config.HTTPClient = hc
+	client.baseUpstreamURL, _ = url.Parse(ts.URL)
+
+	defer ts.Close()
+	if err != nil {
+		t.Error(err)
+	}
+	client.ProxyHandler(w, r)
+	resp := w.Result()
+	if resp.StatusCode != 200 {
+		t.Errorf("Expected status: 200 got %d.", resp.StatusCode)
+	}
+}

--- a/pkg/backends/reverseproxy/routes.go
+++ b/pkg/backends/reverseproxy/routes.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"net/http"
+	"strings"
+
+	oo "github.com/tricksterproxy/trickster/pkg/backends/options"
+	"github.com/tricksterproxy/trickster/pkg/proxy/handlers"
+	"github.com/tricksterproxy/trickster/pkg/proxy/methods"
+	"github.com/tricksterproxy/trickster/pkg/proxy/paths/matching"
+	po "github.com/tricksterproxy/trickster/pkg/proxy/paths/options"
+)
+
+func (c *Client) registerHandlers() {
+	c.handlersRegistered = true
+	c.handlers = make(map[string]http.Handler)
+	// This is the registry of handlers that Trickster supports for the Reverse Proxy Cache,
+	// and are able to be referenced by name (map key) in Config Files
+	c.handlers["health"] = http.HandlerFunc(c.HealthHandler)
+	c.handlers["proxy"] = http.HandlerFunc(c.ProxyHandler)
+	c.handlers["localresponse"] = http.HandlerFunc(handlers.HandleLocalResponse)
+}
+
+// Handlers returns a map of the HTTP Handlers the client has registered
+func (c *Client) Handlers() map[string]http.Handler {
+	if !c.handlersRegistered {
+		c.registerHandlers()
+	}
+	return c.handlers
+}
+
+// DefaultPathConfigs returns the default PathConfigs for the given Provider
+func (c *Client) DefaultPathConfigs(oc *oo.Options) map[string]*po.Options {
+
+	am := methods.AllHTTPMethods()
+
+	paths := map[string]*po.Options{
+		"/-" + strings.Join(am, "-"): {
+			Path:          "/",
+			HandlerName:   "proxy",
+			Methods:       methods.AllHTTPMethods(),
+			MatchType:     matching.PathMatchTypePrefix,
+			MatchTypeName: "prefix",
+		},
+	}
+	return paths
+}

--- a/pkg/backends/reverseproxy/routes.go
+++ b/pkg/backends/reverseproxy/routes.go
@@ -30,7 +30,7 @@ import (
 func (c *Client) registerHandlers() {
 	c.handlersRegistered = true
 	c.handlers = make(map[string]http.Handler)
-	// This is the registry of handlers that Trickster supports for the Reverse Proxy Cache,
+	// This is the registry of handlers that Trickster supports for the Reverse Proxy,
 	// and are able to be referenced by name (map key) in Config Files
 	c.handlers["health"] = http.HandlerFunc(c.HealthHandler)
 	c.handlers["proxy"] = http.HandlerFunc(c.ProxyHandler)

--- a/pkg/backends/reverseproxy/routes_test.go
+++ b/pkg/backends/reverseproxy/routes_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"testing"
+
+	"github.com/tricksterproxy/trickster/pkg/proxy/request"
+	tu "github.com/tricksterproxy/trickster/pkg/util/testing"
+)
+
+const localResponse = "localresponse"
+
+func TestRegisterHandlers(t *testing.T) {
+	c := &Client{}
+	c.registerHandlers()
+	if _, ok := c.handlers[localResponse]; !ok {
+		t.Errorf("expected to find handler named: %s", localResponse)
+	}
+}
+
+func TestHandlers(t *testing.T) {
+	c := &Client{}
+	m := c.Handlers()
+	if _, ok := m[localResponse]; !ok {
+		t.Errorf("expected to find handler named: %s", localResponse)
+	}
+}
+
+func TestDefaultPathConfigs(t *testing.T) {
+	client := &Client{name: "test"}
+	ts, _, r, hc, err := tu.NewTestInstance("", client.DefaultPathConfigs, 200, "{}", nil, "rpc", "/", "debug")
+	rsc := request.GetResources(r)
+	rsc.BackendClient = client
+	client.config = rsc.BackendOptions
+	client.webClient = hc
+	defer ts.Close()
+	if err != nil {
+		t.Error(err)
+	}
+
+	dpc := client.DefaultPathConfigs(client.config)
+
+	if _, ok := dpc["/-GET-HEAD-POST-PUT-DELETE-CONNECT-OPTIONS-TRACE-PATCH-PURGE"]; !ok {
+		t.Errorf("expected to find path named: %s", "/")
+	}
+
+	const expectedLen = 1
+	if len(dpc) != expectedLen {
+		t.Errorf("expected ordered length to be: %d got %d", expectedLen, len(dpc))
+	}
+
+}

--- a/pkg/backends/reverseproxy/rp.go
+++ b/pkg/backends/reverseproxy/rp.go
@@ -34,7 +34,6 @@ var _ backends.Client = (*Client)(nil)
 type Client struct {
 	name               string
 	config             *oo.Options
-	cache              cache.Cache
 	webClient          *http.Client
 	handlers           map[string]http.Handler
 	handlersRegistered bool
@@ -46,11 +45,10 @@ type Client struct {
 }
 
 // NewClient returns a new Client Instance
-func NewClient(name string, oc *oo.Options, router http.Handler,
-	cache cache.Cache) (backends.Client, error) {
+func NewClient(name string, oc *oo.Options, router http.Handler) (backends.Client, error) {
 	c, err := proxy.NewHTTPClient(oc)
 	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
-	return &Client{name: name, config: oc, router: router, cache: cache,
+	return &Client{name: name, config: oc, router: router,
 		webClient: c, baseUpstreamURL: bur}, err
 }
 
@@ -64,9 +62,9 @@ func (c *Client) HTTPClient() *http.Client {
 	return c.webClient
 }
 
-// Cache returns and handle to the Cache instance used by the Client
+// Cache is ineffectual for Reverse Proxies
 func (c *Client) Cache() cache.Cache {
-	return c.cache
+	return nil
 }
 
 // Name returns the name of the upstream Configuration proxied by the Client
@@ -74,10 +72,8 @@ func (c *Client) Name() string {
 	return c.name
 }
 
-// SetCache sets the Cache object the client will use when caching origin content
-func (c *Client) SetCache(cc cache.Cache) {
-	c.cache = cc
-}
+// SetCache is ineffectual for Reverse Proxies
+func (c *Client) SetCache(cc cache.Cache) {}
 
 // Router returns the http.Handler that handles request routing for this Client
 func (c *Client) Router() http.Handler {

--- a/pkg/backends/reverseproxy/rp.go
+++ b/pkg/backends/reverseproxy/rp.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package reverseproxy provides the HTTP Reverse Proxy (no caching) Backend provider
+package reverseproxy
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/tricksterproxy/trickster/pkg/backends"
+	oo "github.com/tricksterproxy/trickster/pkg/backends/options"
+	"github.com/tricksterproxy/trickster/pkg/cache"
+	"github.com/tricksterproxy/trickster/pkg/proxy"
+	"github.com/tricksterproxy/trickster/pkg/proxy/urls"
+)
+
+var _ backends.Client = (*Client)(nil)
+
+// Client Implements the Proxy Client Interface
+type Client struct {
+	name               string
+	config             *oo.Options
+	cache              cache.Cache
+	webClient          *http.Client
+	handlers           map[string]http.Handler
+	handlersRegistered bool
+	baseUpstreamURL    *url.URL
+	healthURL          *url.URL
+	healthMethod       string
+	healthHeaders      http.Header
+	router             http.Handler
+}
+
+// NewClient returns a new Client Instance
+func NewClient(name string, oc *oo.Options, router http.Handler,
+	cache cache.Cache) (backends.Client, error) {
+	c, err := proxy.NewHTTPClient(oc)
+	bur := urls.FromParts(oc.Scheme, oc.Host, oc.PathPrefix, "", "")
+	return &Client{name: name, config: oc, router: router, cache: cache,
+		webClient: c, baseUpstreamURL: bur}, err
+}
+
+// Configuration returns the upstream Configuration for this Client
+func (c *Client) Configuration() *oo.Options {
+	return c.config
+}
+
+// HTTPClient returns the HTTP Transport the client is using
+func (c *Client) HTTPClient() *http.Client {
+	return c.webClient
+}
+
+// Cache returns and handle to the Cache instance used by the Client
+func (c *Client) Cache() cache.Cache {
+	return c.cache
+}
+
+// Name returns the name of the upstream Configuration proxied by the Client
+func (c *Client) Name() string {
+	return c.name
+}
+
+// SetCache sets the Cache object the client will use when caching origin content
+func (c *Client) SetCache(cc cache.Cache) {
+	c.cache = cc
+}
+
+// Router returns the http.Handler that handles request routing for this Client
+func (c *Client) Router() http.Handler {
+	return c.router
+}

--- a/pkg/backends/reverseproxy/rp_test.go
+++ b/pkg/backends/reverseproxy/rp_test.go
@@ -23,7 +23,7 @@ import (
 	oo "github.com/tricksterproxy/trickster/pkg/backends/options"
 )
 
-func TestReverseProxyCacheClientInterfacing(t *testing.T) {
+func TestReverseProxyClientInterfacing(t *testing.T) {
 
 	// this test ensures the client will properly conform to the
 	// Client interface
@@ -38,7 +38,7 @@ func TestReverseProxyCacheClientInterfacing(t *testing.T) {
 }
 
 func TestNewNewClient(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func TestNewNewClient(t *testing.T) {
 }
 
 func TestHTTPClient(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -58,17 +58,17 @@ func TestHTTPClient(t *testing.T) {
 }
 
 func TestGetCache(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}
 	if c.Cache() != nil {
-		t.Errorf("expected nil Cache for RPC client named %s", "test")
+		t.Errorf("expected nil Cache for RP client named %s", "test")
 	}
 }
 
 func TestClientName(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -78,7 +78,7 @@ func TestClientName(t *testing.T) {
 }
 
 func TestSetCache(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -89,7 +89,7 @@ func TestSetCache(t *testing.T) {
 }
 
 func TestConfiguration(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -99,7 +99,7 @@ func TestConfiguration(t *testing.T) {
 }
 
 func TestRouter(t *testing.T) {
-	c, err := NewClient("test", oo.New(), nil, nil)
+	c, err := NewClient("test", oo.New(), nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/backends/reverseproxy/rp_test.go
+++ b/pkg/backends/reverseproxy/rp_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reverseproxy
+
+import (
+	"testing"
+
+	"github.com/tricksterproxy/trickster/pkg/backends"
+	oo "github.com/tricksterproxy/trickster/pkg/backends/options"
+)
+
+func TestReverseProxyCacheClientInterfacing(t *testing.T) {
+
+	// this test ensures the client will properly conform to the
+	// Client interface
+
+	c := &Client{name: "test"}
+	var oc backends.Client = c
+
+	if oc.Name() != "test" {
+		t.Errorf("expected %s got %s", "test", oc.Name())
+	}
+
+}
+
+func TestNewNewClient(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if c == nil {
+		t.Errorf("expected client named %s", "test")
+	}
+}
+
+func TestHTTPClient(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if c.HTTPClient() == nil {
+		t.Errorf("expected HTTPClient for RPC client named %s", "test")
+	}
+}
+
+func TestGetCache(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if c.Cache() != nil {
+		t.Errorf("expected nil Cache for RPC client named %s", "test")
+	}
+}
+
+func TestClientName(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if c.Name() != "test" {
+		t.Errorf("expected RPC client named %s", "test")
+	}
+}
+
+func TestSetCache(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	c.SetCache(nil)
+	if c.Cache() != nil {
+		t.Errorf("expected nil cache for client named %s", "test")
+	}
+}
+
+func TestConfiguration(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if c.Configuration() == nil {
+		t.Error("expected non-nil config")
+	}
+}
+
+func TestRouter(t *testing.T) {
+	c, err := NewClient("test", oo.New(), nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+	if c.Router() != nil {
+		t.Error("expected nil router")
+	}
+}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -35,6 +35,7 @@ import (
 	"github.com/tricksterproxy/trickster/pkg/backends/prometheus"
 	modelprom "github.com/tricksterproxy/trickster/pkg/backends/prometheus/model"
 	"github.com/tricksterproxy/trickster/pkg/backends/providers"
+	"github.com/tricksterproxy/trickster/pkg/backends/reverseproxy"
 	"github.com/tricksterproxy/trickster/pkg/backends/reverseproxycache"
 	"github.com/tricksterproxy/trickster/pkg/backends/rule"
 	"github.com/tricksterproxy/trickster/pkg/cache"
@@ -165,6 +166,8 @@ func registerBackendRoutes(router *mux.Router, conf *config.Config, k string,
 		client, err = clickhouse.NewClient(k, o, mux.NewRouter(), c, modelch.NewModeler())
 	case "rpc", "reverseproxycache":
 		client, err = reverseproxycache.NewClient(k, o, mux.NewRouter(), c)
+	case "rp", "reverseproxy", "proxy":
+		client, err = reverseproxy.NewClient(k, o, mux.NewRouter(), c)
 	case "rule":
 		client, err = rule.NewClient(k, o, mux.NewRouter(), clients)
 	}

--- a/pkg/util/metrics/metrics.go
+++ b/pkg/util/metrics/metrics.go
@@ -142,7 +142,7 @@ func init() {
 			Name:      "requests_total",
 			Help:      "Count of front end requests handled by Trickster",
 		},
-		[]string{"origin_name", "provider", "method", "path", "http_status"},
+		[]string{"backend_name", "provider", "method", "path", "http_status"},
 	)
 
 	FrontendRequestDuration = prometheus.NewHistogramVec(
@@ -153,7 +153,7 @@ func init() {
 			Help:      "Histogram of front end request durations handled by Trickster",
 			Buckets:   defaultBuckets,
 		},
-		[]string{"origin_name", "provider", "method", "path", "http_status"},
+		[]string{"backend_name", "provider", "method", "path", "http_status"},
 	)
 
 	FrontendRequestWrittenBytes = prometheus.NewCounterVec(
@@ -163,7 +163,7 @@ func init() {
 			Name:      "written_bytes_total",
 			Help:      "Count of bytes written in front end requests handled by Trickster",
 		},
-		[]string{"origin_name", "provider", "method", "path", "http_status"})
+		[]string{"backend_name", "provider", "method", "path", "http_status"})
 
 	ProxyRequestStatus = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -172,7 +172,7 @@ func init() {
 			Name:      "requests_total",
 			Help:      "Count of downstream client requests handled by Trickster",
 		},
-		[]string{"origin_name", "provider", "method", "cache_status", "http_status", "path"},
+		[]string{"backend_name", "provider", "method", "cache_status", "http_status", "path"},
 	)
 
 	ProxyRequestElements = prometheus.NewCounterVec(
@@ -182,7 +182,7 @@ func init() {
 			Name:      "points_total",
 			Help:      "Count of data points in the timeseries returned to the requesting client.",
 		},
-		[]string{"origin_name", "provider", "cache_status", "path"},
+		[]string{"backend_name", "provider", "cache_status", "path"},
 	)
 
 	ProxyRequestDuration = prometheus.NewHistogramVec(
@@ -193,7 +193,7 @@ func init() {
 			Help:      "Time required in seconds to proxy a given Prometheus query.",
 			Buckets:   defaultBuckets,
 		},
-		[]string{"origin_name", "provider", "method", "status", "http_status", "path"},
+		[]string{"backend_name", "provider", "method", "status", "http_status", "path"},
 	)
 
 	ProxyMaxConnections = prometheus.NewGauge(


### PR DESCRIPTION
This contribution adds a basic reverse proxy to Trickster by using provider type `rp`, `proxy`, or `reverseproxy`. It has always been possible to configure the Reverse Proxy Cache backend to use the proxy instead of the proxy cache; but this new provider type is more direct and does not require any under-the-hood customization knowledge in order to accomplish this basic feature.