### PR TITLE
Updated example configuration files to use 'origin_type' instead of 'provider' in origin configs

### DIFF
--- a/cmd/trickster/conf/example.conf
+++ b/cmd/trickster/conf/example.conf
@@ -250,10 +250,11 @@ listen_port = 8480
     # access this backend via http[s]://trickster-fqdn/default/ unless path_routing_disabled is true
     [backends.default]
 
-    # provider identifies the backend provider.
-    # Valid options are: 'prometheus', 'influxdb', 'clickhouse', 'irondb', 'reverseproxycache' (or just 'rpc')
-    # provider is a required configuration value
-    provider = 'prometheus'
+    # origin_type identifies the backend origin type.
+    # Valid options are: 'prometheus', 'influxdb', 'clickhouse', 'irondb', 'reverseproxycache' (or just 'rpc'),
+    # 'reverseproxy' (or just 'rp'), and 'rule'
+    # origin_type is a required configuration value
+    origin_type = 'prometheus'
 
     # origin_url provides the base upstream URL for all proxied requests to this origin.
     # it can be as simple as http://example.com or as complex as https://example.com:8443/path/prefix
@@ -291,7 +292,7 @@ listen_port = 8480
     # path_routing_disabled = false
 
     ## rule_name provides the name of the rule config to be used by this backend.
-    ## This is only effective if the provider is 'rule'
+    ## This is only effective if the origin_type is 'rule'
     # rule_name = 'example-rule'
 
     ## req_rewriter_name is the name of a configured rewriter (in [request_rewriters]) that will modify the request prior to
@@ -362,7 +363,7 @@ listen_port = 8480
     # fastforward_ttl_ms = 15000
 
     ##
-    ## Each backend provider implements their own defaults for health_check_upstream_url, health_check_verb and health_check_query,
+    ## Each backend origin_type implements their own defaults for health_check_upstream_url, health_check_verb and health_check_query,
     ## which can be overridden per backend. See /docs/health.md for more information
     
     ## health_check_upstream_url is the URL Trickster will request against this backend to
@@ -453,7 +454,7 @@ listen_port = 8480
     ## use quotes around FQDNs for host-based routing (see /docs/multi-backend.md).
     # [backends.'foo.example.com']
     # is_default = false
-    # provider = 'influxdb'
+    # origin_type = 'influxdb'
     # origin_url = 'http://influx-origin:8086'
     # cache_name = 'bbolt_example'
     # negative_cache_name = 'general'

--- a/cmd/trickster/conf/simple.prometheus.conf
+++ b/cmd/trickster/conf/simple.prometheus.conf
@@ -18,7 +18,7 @@ listen_port = 9090
 
     # update FQDN and Port to work in your environment
     origin_url = 'http://prometheus:9090'
-    provider = 'prometheus'
+    origin_type = 'prometheus'
 
 [metrics]
 listen_port = 8481   # available for scraping at http://<trickster>:<metrics.listen_port>/metrics

--- a/cmd/trickster/conf/simple.reverseproxycache.conf
+++ b/cmd/trickster/conf/simple.reverseproxycache.conf
@@ -18,7 +18,7 @@ listen_port = 8480
 
     # update FQDN and (optional) Port to work in your environment
     origin_url = 'http://api.example.com:2379'
-    provider = 'reverseproxycache'
+    origin_type = 'reverseproxycache'
 
 [metrics]
 listen_port = 8481   # available for scraping at http://<trickster>:<metrics.listen_port>/metrics

--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -259,10 +259,11 @@ data:
         # access this origin via http[s]://trickster-fqdn/default/ unless path_routing_disabled is true
         [origins.default]
 
-        # provider identifies the origin type.
-        # Valid options are: 'prometheus', 'influxdb', 'clickhouse', 'irondb', 'reverseproxycache' (or just 'rpc')
-        # provider is a required configuration value
-        provider = 'prometheus'
+        # origin_type identifies the backend origin type.
+        # Valid options are: 'prometheus', 'influxdb', 'clickhouse', 'irondb', 'reverseproxycache' (or just 'rpc'),
+        # 'reverseproxy' (or just 'rp'), and 'rule'
+        # origin_type is a required configuration value
+        origin_type = 'prometheus'
 
         # origin_url provides the base upstream URL for all proxied requests to this origin.
         # it can be as simple as http://example.com or as complex as https://example.com:8443/path/prefix
@@ -300,7 +301,7 @@ data:
         # path_routing_disabled = false
 
         ## rule_name provides the name of the rule config to be used by this origin.
-        ## This is only effective if the provider is 'rule'
+        ## This is only effective if the origin_type is 'rule'
         # rule_name = 'example-rule'
 
         ## req_rewriter_name is the name of a configured rewriter (in [request_rewriters]) that will modify the request prior to
@@ -462,7 +463,7 @@ data:
         ## use quotes around FQDNs for host-based routing (see /docs/multi-origin.md).
         # [origins.'foo.example.com']
         # is_default = false
-        # provider = 'influxdb'
+        # origin_type = 'influxdb'
         # origin_url = 'http://influx-origin:8086'
         # cache_name = 'bbolt_example'
         # negative_cache_name = 'general'

--- a/deploy/trickster-demo/docker-compose-data/trickster-config/trickster.conf
+++ b/deploy/trickster-demo/docker-compose-data/trickster-config/trickster.conf
@@ -50,31 +50,31 @@ listen_port = 8480
 
 [origins]
   [origins.prom1] # prometheus cached with a memory cache, traces sent to stdout
-  provider = 'prometheus'
+  origin_type = 'prometheus'
   origin_url = 'http://prometheus:9090'
   tracing_name = 'std1'
   cache_name = 'mem1'
 
   [origins.prom2] # prometheus cached with a filesystem cache, traces sent to jaeger collector
-  provider = 'prometheus'
+  origin_type = 'prometheus'
   origin_url = 'http://prometheus:9090'
   tracing_name = 'jc1'
   cache_name = 'fs1'
 
   [origins.sim1] # simulated prometheus cached with a memory cache, traces sent to jaeger agent
-  provider = 'prometheus'
+  origin_type = 'prometheus'
   origin_url = 'http://mockster:8482/prometheus'
   tracing_name = 'ja1'
   cache_name = 'mem1'
 
   [origins.sim2] # simulated prometheus cached with a Redis cache, traces sent to jaeger agent
-  provider = 'prometheus'
+  origin_type = 'prometheus'
   origin_url = 'http://mockster:8482/prometheus'
   tracing_name = 'ja1'
   cache_name = 'rds1'
 
   [origins.rpc1] # memory reverse proxy cache of the byterange request simulation endpoint, traces sent to jager agent
-  provider = 'reverseproxycache'
+  origin_type = 'reverseproxycache'
   origin_url = 'http://mockster:8482/byterange'
   tracing_name = 'ja1'
   cache_name = 'mem1'


### PR DESCRIPTION
I noticed when configuring Trickster that some of the example config files had the out-of-date field `provider` in their origin configurations. It started working once I changed them to `origin_type`. This PR is just updating those config files. I think I got them all, but let me know if I missed one.