### PR TITLE
Using closed intervals to avoid gaps in partially cached timeseries

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -310,7 +310,7 @@ checkCache:
 			if resp.StatusCode == http.StatusOK && len(body) > 0 {
 				nts, err := client.UnmarshalTimeseries(body)
 				if err != nil {
-					pr.Logger.Error("proxy object unmarshaling failed",
+					pr.Logger.Error("proxy object unmarshalling failed",
 						tl.Pairs{"body": string(body)})
 					return
 				}

--- a/pkg/proxy/engines/httpproxy_test.go
+++ b/pkg/proxy/engines/httpproxy_test.go
@@ -131,7 +131,7 @@ func TestProxyRequestBadGateway(t *testing.T) {
 func TestClockOffsetWarning(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Add(headers.NameDate, time.Now().Add(-1*time.Hour).Format(http.TimeFormat))
+		w.Header().Add(headers.NameDate, time.Now().UTC().Add(-1*time.Hour).Format(http.TimeFormat))
 		w.WriteHeader(200)
 	}
 	s := httptest.NewServer(http.HandlerFunc(handler))

--- a/pkg/proxy/origins/influxdb/tokenization.go
+++ b/pkg/proxy/origins/influxdb/tokenization.go
@@ -56,9 +56,9 @@ func init() {
 		`(?P<offset2>[0-9]+[mhsdwy]))))(\s+(?P<postOp2>and|or|group|order|limit)|$)`)
 }
 
-func interpolateTimeQuery(template string, extent *timeseries.Extent) string {
-	return strings.Replace(template, tkTime, fmt.Sprintf("time >= %dms AND time <= %dms",
-		extent.Start.Unix()*1000, extent.End.Unix()*1000), -1)
+func interpolateTimeQuery(template string, trq *timeseries.TimeRangeQuery, extent *timeseries.Extent) string {
+	return strings.Replace(template, tkTime, fmt.Sprintf("time >= %dms AND time < %dms",
+		extent.Start.Unix()*1000, extent.End.Add(trq.Step).Unix()*1000), -1)
 }
 
 func getQueryParts(query string) (string, timeseries.Extent) {

--- a/pkg/proxy/origins/influxdb/url.go
+++ b/pkg/proxy/origins/influxdb/url.go
@@ -44,7 +44,7 @@ func (c Client) SetExtent(r *http.Request, trq *timeseries.TimeRangeQuery, exten
 	t := trq.TemplateURL.Query()
 	q := t.Get(upQuery)
 	if q != "" {
-		v.Set(upQuery, interpolateTimeQuery(q, extent))
+		v.Set(upQuery, interpolateTimeQuery(q, trq, extent))
 	}
 	params.SetRequestValues(r, v)
 }

--- a/pkg/proxy/origins/influxdb/url_test.go
+++ b/pkg/proxy/origins/influxdb/url_test.go
@@ -32,11 +32,12 @@ import (
 
 func TestSetExtent(t *testing.T) {
 
+	step := time.Duration(5) * time.Minute
 	start := time.Now().Add(time.Duration(-6) * time.Hour)
 	end := time.Now()
 	expected := "q=select+%2A+where+time+%3E%3D+" +
 		fmt.Sprintf("%d", start.Unix()*1000) +
-		"ms+AND+time+%3C%3D+" + fmt.Sprintf("%d", end.Unix()*1000) + "ms+group+by+time%281m%29"
+		"ms+AND+time+%3C+" + fmt.Sprintf("%d", end.Add(step).Unix()*1000) + "ms+group+by+time%281m%29"
 
 	conf, _, err := config.Load("trickster", "test",
 		[]string{"-origin-url", "none:9090", "-origin-type", "influxdb", "-log-level", "debug"})
@@ -52,7 +53,7 @@ func TestSetExtent(t *testing.T) {
 	tu := &url.URL{RawQuery: tokenized}
 
 	r, _ := http.NewRequest(http.MethodGet, tu.String(), nil)
-	trq := &timeseries.TimeRangeQuery{TemplateURL: tu}
+	trq := &timeseries.TimeRangeQuery{TemplateURL: tu, Step: step}
 	e := &timeseries.Extent{Start: start, End: end}
 	client.SetExtent(r, trq, e)
 


### PR DESCRIPTION
As explained in #466, when the date range specified is partially catched, the `missRanges` are not calculated properly, generating queries that return gaps in the series.