### PR TITLE
Log upstream request URL instead of the original URL object

### DIFF
--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -175,8 +175,8 @@ func (pr *proxyRequest) Fetch() ([]byte, *http.Response, time.Duration) {
 
 	elapsed := time.Since(start) // includes any time required to decompress the document for deserialization
 
-	go logUpstreamRequest(pr.Logger, oc.Name, oc.Provider, handlerName,
-		pr.Method, pr.URL.String(), pr.UserAgent(), resp.StatusCode, len(body), elapsed.Seconds())
+	go logUpstreamRequest(pr.Logger, oc.Name, oc.Provider, handlerName, pr.upstreamRequest.Method,
+		pr.upstreamRequest.URL.String(), pr.UserAgent(), resp.StatusCode, len(body), elapsed.Seconds())
 
 	return body, resp, elapsed
 }


### PR DESCRIPTION
As comented on #522, access log debug lines are misleading. Trickster is logging as upstream request the actual input path (without the origin prefix path) and query string but with the upstream host instead of Trickster's. This can be observed easily for partially catched time series: Trickster queries the upstream multiple times with the missing date intervals but the logged URL is always the same.

A repro case:
Query Trickster for `/influx1/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611480030000ms+and+time+%3C%3D+1611481500000ms+GROUP+BY+time%2830s%29+fill%28linear%29"`. This should log several missing date interval fetched from upstream, but instead we got the same log several times:
```
time=2021-01-24T09:52:53.885637Z app=trickster caller=cache/memory/memory.go:148 level=debug event="memory cache retrieve" cacheKey=localhost:8086.dpc.57cdda12dccdd7f12d0ee475a4d2e0c1
time=2021-01-24T09:52:53.957876Z app=trickster caller=proxy/engines/access_logs.go:27 level=debug event="upstream request" originType=influxdb handlerName=query userAgent=Grafana/6.7.3 code=200 size=514 durationMS=69 originName=influx1 method=GET uri="http://localhost:8086/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611480030000ms+and+time+%3C%3D+1611481500000ms+GROUP+BY+time%2830s%29+fill%28linear%29"
time=2021-01-24T09:52:53.960153Z app=trickster caller=proxy/engines/access_logs.go:27 level=debug event="upstream request" originType=influxdb code=200 size=315 durationMS=70 originName=influx1 method=GET uri="http://localhost:8086/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611480030000ms+and+time+%3C%3D+1611481500000ms+GROUP+BY+time%2830s%29+fill%28linear%29" userAgent=Grafana/6.7.3 handlerName=query
time=2021-01-24T09:52:53.97527Z app=trickster caller=proxy/engines/access_logs.go:27 level=debug event="upstream request" originType=influxdb handlerName=query method=GET uri="http://localhost:8086/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611480030000ms+and+time+%3C%3D+1611481500000ms+GROUP+BY+time%2830s%29+fill%28linear%29" code=200 durationMS=86 originName=influx1 userAgent=Grafana/6.7.3 size=33
```

With this fix, it just logs the actual upstream requests that were executed:
```
time=2021-01-24T10:06:00.566316Z app=trickster caller=proxy/engines/access_logs.go:27 level=debug event="upstream request" originType=influxdb uri="http://localhost:8086/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611481530000ms+AND+time+%3C%3D+1611481800000ms+GROUP+BY+time%2830s%29+fill%28linear%29" userAgent=Grafana/6.7.3 size=437 durationMS=59 originName=influx1 handlerName=query method=GET code=200
time=2021-01-24T10:06:00.566311Z app=trickster caller=proxy/engines/access_logs.go:27 level=debug event="upstream request" originType=influxdb handlerName=query method=GET uri="http://localhost:8086/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611482130000ms+AND+time+%3C%3D+1611482340000ms+GROUP+BY+time%2830s%29+fill%28linear%29" size=367 durationMS=59 originName=influx1 userAgent=Grafana/6.7.3 code=200
time=2021-01-24T10:06:00.566651Z app=trickster caller=proxy/engines/access_logs.go:27 level=debug event="upstream request" userAgent=Grafana/6.7.3 size=434 originName=influx1 handlerName=query method=GET uri="http://localhost:8086/query?db=inspectit&epoch=ms&q=SELECT+mean%28%22value%22%29+FROM+%22system_load_average_1m%22+WHERE+%28%22host%22+%3D~+%2F%5E44a9e042a4ca%24%2F%29+AND+time+%3E%3D+1611480930000ms+AND+time+%3C%3D+1611481200000ms+GROUP+BY+time%2830s%29+fill%28linear%29" originType=influxdb code=200 durationMS=59
time=2021-01-24T10:06:00.567037Z app=trickster caller=runtime/asm_amd64.s:1374 level=debug event="memorycache cache store" ttl=6h0m0s is_direct=true cacheKey=localhost:8086.dpc.57cdda12dccdd7f12d0ee475a4d2e0c1 length=0
```