### PR TITLE
Log upstream request URL instead of the original URL object (backport to 1.1.x)

### DIFF
--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -174,7 +174,7 @@ func (pr *proxyRequest) Fetch() ([]byte, *http.Response, time.Duration) {
 	elapsed := time.Since(start) // includes any time required to decompress the document for deserialization
 
 	go logUpstreamRequest(pr.Logger, oc.Name, oc.OriginType, handlerName,
-		pr.Method, pr.URL.String(), pr.UserAgent(), resp.StatusCode, len(body), elapsed.Seconds())
+		pr.upstreamRequest.Method, pr.upstreamRequest.URL.String(), pr.UserAgent(), resp.StatusCode, len(body), elapsed.Seconds())
 
 	return body, resp, elapsed
 }


### PR DESCRIPTION
Backport to `1.1.x` branch from #524 