### PR TITLE
move health handler to metrics port

### DIFF
--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -151,8 +151,8 @@ var noCacheBackends = map[string]bool{
 }
 
 // RegisterHealthHandler registers the main health handler
-func RegisterHealthHandler(router *mux.Router, path string, hc healthcheck.HealthChecker) *mux.Route {
-	return router.Path(path).Handler(health.StatusHandler(hc)).Methods(http.MethodGet, http.MethodHead)
+func RegisterHealthHandler(router *http.ServeMux, path string, hc healthcheck.HealthChecker) {
+	router.Handle(path, health.StatusHandler(hc))
 }
 
 func registerBackendRoutes(router *mux.Router, conf *config.Config, k string,

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -51,14 +51,10 @@ func TestRegisterPprofRoutes(t *testing.T) {
 }
 
 func TestRegisterHealthHandler(t *testing.T) {
-	router := mux.NewRouter()
+	router := http.NewServeMux()
 	path := "/test"
 	hc := healthcheck.New()
-
-	route := RegisterHealthHandler(router, path, hc)
-	if route == nil {
-		t.Error("expected non-nil route")
-	}
+	RegisterHealthHandler(router, path, hc)
 }
 
 func TestRegisterProxyRoutes(t *testing.T) {


### PR DESCRIPTION
this patch moves the health handler to be routable via the metrics listener port, rather than the main frontend port.