### PR TITLE
configurable rounding value for instant queries

### DIFF
--- a/pkg/backends/prometheus/handler_query.go
+++ b/pkg/backends/prometheus/handler_query.go
@@ -43,7 +43,7 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 	// and if so, sets up the request context for these scenarios
 	if rsc.IsMergeMember || (rsc.BackendOptions != nil && rsc.BackendOptions.Prometheus != nil) {
 		var trq *timeseries.TimeRangeQuery
-		trq, err = parseVectorQuery(r)
+		trq, err = parseVectorQuery(r, c.instantRounder)
 		if err == nil {
 			rsc.TimeRangeQuery = trq
 			hasTransformations = len(trq.Labels) > 0
@@ -61,7 +61,7 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 	// Round time param down to the nearest 15 seconds if it exists
 	if p := qp.Get(upTime); p != "" {
 		if i, err := strconv.ParseInt(p, 10, 64); err == nil {
-			qp.Set(upTime, strconv.FormatInt(time.Unix(i, 0).Truncate(time.Second*time.Duration(15)).Unix(), 10))
+			qp.Set(upTime, strconv.FormatInt(time.Unix(i, 0).Truncate(c.instantRounder).Unix(), 10))
 		}
 	}
 	r.URL = u

--- a/pkg/backends/prometheus/options/defaults.go
+++ b/pkg/backends/prometheus/options/defaults.go
@@ -16,8 +16,5 @@
 
 package options
 
-// Options stores information about Prometheus Options
-type Options struct {
-	Labels         map[string]string `yaml:"labels,omitempty"`
-	InstantRoundMS int               `yaml:"instant_round_ms,omitempty"`
-}
+// DefaultInstantRoundMS is the default Instant Rounding Value for Prometheus
+const DefaultInstantRoundMS = 15000

--- a/pkg/backends/prometheus/prometheus_test.go
+++ b/pkg/backends/prometheus/prometheus_test.go
@@ -381,7 +381,9 @@ func TestParseVectorQuery(t *testing.T) {
 	rsc := request.NewResources(o, nil, nil, nil, nil, nil, nil)
 	req = request.SetResources(req, rsc)
 
-	_, err := parseVectorQuery(req)
+	rounder := time.Second * 15
+
+	_, err := parseVectorQuery(req, rounder)
 	if err != nil {
 		t.Error(err)
 	}
@@ -395,7 +397,7 @@ func TestParseVectorQuery(t *testing.T) {
 		}).Encode(),
 	}}
 
-	_, err = parseVectorQuery(req)
+	_, err = parseVectorQuery(req, rounder)
 	if err == nil {
 		t.Error("expected error for missing parameter")
 	}
@@ -410,7 +412,7 @@ func TestParseVectorQuery(t *testing.T) {
 		}).Encode(),
 	}}
 
-	_, err = parseVectorQuery(req)
+	_, err = parseVectorQuery(req, rounder)
 	if err == nil {
 		t.Error("expected error for time parsing")
 	}
@@ -424,7 +426,7 @@ func TestParseVectorQuery(t *testing.T) {
 		}).Encode(),
 	}}
 
-	_, err = parseVectorQuery(req)
+	_, err = parseVectorQuery(req, rounder)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
this allows a user-configurable rounding value for instantaneous prometheus queries, instead of hardcoding to 15 seconds. (Default is still 15)