### PR TITLE
2.0 backfill tolerance update

### DIFF
--- a/pkg/backends/irondb/model/model.go
+++ b/pkg/backends/irondb/model/model.go
@@ -35,10 +35,11 @@ import (
 // SeriesEnvelope values represent a time series data response from the
 // IRONdb API.
 type SeriesEnvelope struct {
-	Data           DataPoints            `json:"data"`
-	ExtentList     timeseries.ExtentList `json:"extents,omitempty"`
-	StepDuration   time.Duration         `json:"step,omitempty"`
-	timeRangeQuery *timeseries.TimeRangeQuery
+	Data               DataPoints            `json:"data"`
+	ExtentList         timeseries.ExtentList `json:"extents,omitempty"`
+	StepDuration       time.Duration         `json:"step,omitempty"`
+	timeRangeQuery     *timeseries.TimeRangeQuery
+	VolatileExtentList timeseries.ExtentList `json:"-"`
 }
 
 // MarshalJSON encodes a series envelope value into a JSON byte slice.
@@ -100,6 +101,14 @@ func (se *SeriesEnvelope) UnmarshalJSON(b []byte) error {
 
 	err := json.Unmarshal(b, &se.Data)
 	return err
+}
+
+func (se *SeriesEnvelope) VolatileExtents() timeseries.ExtentList {
+	return se.VolatileExtentList
+}
+
+func (se *SeriesEnvelope) SetVolatileExtents(e timeseries.ExtentList) {
+	se.VolatileExtentList = e
 }
 
 // DataPoint values represent a single data element of a time series data

--- a/pkg/backends/irondb/model/model_df4.go
+++ b/pkg/backends/irondb/model/model_df4.go
@@ -34,6 +34,9 @@ type DF4SeriesEnvelope struct {
 	StepDuration   time.Duration            `json:"step,omitempty"`
 	ExtentList     timeseries.ExtentList    `json:"extents,omitempty"`
 	timeRangeQuery *timeseries.TimeRangeQuery
+	// VolatileExtents is the list extents in the dataset that should be refreshed
+	// on the next request to the Origin
+	VolatileExtentList timeseries.ExtentList `json:"-"`
 }
 
 // DF4Info values contain information about the timestamps of the data elements
@@ -363,4 +366,12 @@ func (se *DF4SeriesEnvelope) Size() int64 {
 	}
 	wg.Wait()
 	return c
+}
+
+func (se *DF4SeriesEnvelope) VolatileExtents() timeseries.ExtentList {
+	return se.VolatileExtentList
+}
+
+func (se *DF4SeriesEnvelope) SetVolatileExtents(e timeseries.ExtentList) {
+	se.VolatileExtentList = e
 }

--- a/pkg/backends/options/defaults.go
+++ b/pkg/backends/options/defaults.go
@@ -47,6 +47,8 @@ const (
 	DefaultTracingConfigName = "default"
 	// DefaultBackfillToleranceMS is the default Backfill Tolerance setting for Backends
 	DefaultBackfillToleranceMS = 0
+	// DefaultBackfillTolerancePoints is the default Backfill Tolerance setting for Backends
+	DefaultBackfillTolerancePoints = 0
 	// DefaultKeepAliveTimeoutMS is the default Keep Alive Timeout for Backends' upstream client pools
 	DefaultKeepAliveTimeoutMS = 300000
 	// DefaultMaxIdleConns is the default number of Idle Connections in Backends' upstream client pools

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -84,7 +84,7 @@ type Options struct {
 	// BackfillTolerancePoints is similar to the MS version, except that it's final value is dependent
 	// on the query step value to determin the relative duration of backfill tolerance per-query
 	// When both are set, the higher of the two values is used
-	BackfillTolerancePoints int64 `yaml:"backfill_tolerance_points,omitempty"`
+	BackfillTolerancePoints int `yaml:"backfill_tolerance_points,omitempty"`
 	// PathList is a list of Path Options that control the behavior of the given paths when requested
 	Paths map[string]*po.Options `yaml:"paths,omitempty"`
 	// NegativeCacheName provides the name of the Negative Cache Config to be used by this Backend

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -77,10 +77,14 @@ type Options struct {
 	// TimeseriesEvictionMethodName specifies which methodology ("oldest", "lru") is used to identify
 	//timeseries to evict from a full cache object
 	TimeseriesEvictionMethodName string `yaml:"timeseries_eviction_method,omitempty"`
-	// BackfillToleranceMS prevents values with timestamps newer than the provided
-	// number of seconds from being cached this allows propagation of upstream backfill operations
-	// that modify recently-served data
+	// BackfillToleranceMS prevents values with timestamps newer than the provided number of
+	// milliseconds from being cached. this allows propagation of upstream backfill operations
+	// that modify recently-cached data
 	BackfillToleranceMS int64 `yaml:"backfill_tolerance_ms,omitempty"`
+	// BackfillTolerancePoints is similar to the MS version, except that it's final value is dependent
+	// on the query step value to determin the relative duration of backfill tolerance per-query
+	// When both are set, the higher of the two values is used
+	BackfillTolerancePoints int64 `yaml:"backfill_tolerance_points,omitempty"`
 	// PathList is a list of Path Options that control the behavior of the given paths when requested
 	Paths map[string]*po.Options `yaml:"paths,omitempty"`
 	// NegativeCacheName provides the name of the Negative Cache Config to be used by this Backend
@@ -188,8 +192,9 @@ type Options struct {
 // New will return a pointer to a Backend Options with the default configuration settings
 func New() *Options {
 	return &Options{
-		BackfillTolerance:            DefaultBackfillToleranceMS,
+		BackfillTolerance:            time.Duration(DefaultBackfillToleranceMS) * time.Millisecond,
 		BackfillToleranceMS:          DefaultBackfillToleranceMS,
+		BackfillTolerancePoints:      DefaultBackfillTolerancePoints,
 		CacheKeyPrefix:               "",
 		CacheName:                    DefaultBackendCacheName,
 		CompressableTypeList:         DefaultCompressableTypes(),
@@ -226,6 +231,7 @@ func (o *Options) Clone() *Options {
 	no.DearticulateUpstreamRanges = o.DearticulateUpstreamRanges
 	no.BackfillTolerance = o.BackfillTolerance
 	no.BackfillToleranceMS = o.BackfillToleranceMS
+	no.BackfillTolerancePoints = o.BackfillTolerancePoints
 	no.CacheName = o.CacheName
 	no.CacheKeyPrefix = o.CacheKeyPrefix
 	no.FastForwardDisable = o.FastForwardDisable
@@ -550,6 +556,10 @@ func SetDefaults(
 
 	if metadata.IsDefined("backends", name, "backfill_tolerance_ms") {
 		no.BackfillToleranceMS = o.BackfillToleranceMS
+	}
+
+	if metadata.IsDefined("backends", name, "backfill_tolerance_points") {
+		no.BackfillTolerancePoints = o.BackfillTolerancePoints
 	}
 
 	if metadata.IsDefined("backends", name, "paths") {

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -82,7 +82,7 @@ type Options struct {
 	// that modify recently-cached data
 	BackfillToleranceMS int64 `yaml:"backfill_tolerance_ms,omitempty"`
 	// BackfillTolerancePoints is similar to the MS version, except that it's final value is dependent
-	// on the query step value to determin the relative duration of backfill tolerance per-query
+	// on the query step value to determine the relative duration of backfill tolerance per-query
 	// When both are set, the higher of the two values is used
 	BackfillTolerancePoints int `yaml:"backfill_tolerance_points,omitempty"`
 	// PathList is a list of Path Options that control the behavior of the given paths when requested

--- a/pkg/backends/options/options_data_test.go
+++ b/pkg/backends/options/options_data_test.go
@@ -52,6 +52,7 @@ backends:
     timeseries_eviction_method: lru
     fast_forward_disable: true
     backfill_tolerance_ms: 301000
+    backfill_tolerance_points: 2
     timeout_ms: 37000
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
@@ -84,6 +85,12 @@ backends:
         collapsed_forwarding: basic
         response_headers:
           X-Header-Test: test-value
+    prometheus:
+      labels:
+        testlabel: trickster
+    alb:
+      methodology: rr
+      pool: [ test ]
     tls:
       full_chain_cert_path: file.that.should.not.exist.ever.pem
       private_key_path: file.that.should.not.exist.ever.pem

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -89,8 +89,14 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	trq.NormalizeExtent()
 	now := time.Now()
 
-	// determine backfill tolerance start window
-	bt := o.BackfillTolerance              // todo, deterministic when we add in points vs time option
+	// determine backfill tolerance start window MS or Points*Step
+	bt := o.BackfillTolerance
+	if o.BackfillTolerancePoints > 0 {
+		if bt2 := time.Duration(o.BackfillTolerancePoints) * trq.Step; bt2 > bt {
+			bt = bt2
+		}
+	}
+	bt = trq.GetBackfillTolerance(bt)      // set any query override for backfull tolerance
 	bfs := now.Add(-bt).Truncate(trq.Step) // start of the backfill tolerance window
 
 	OldestRetainedTimestamp := time.Time{}

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -89,14 +89,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	trq.NormalizeExtent()
 	now := time.Now()
 
-	// determine backfill tolerance start window MS or Points*Step
-	bt := o.BackfillTolerance
-	if o.BackfillTolerancePoints > 0 {
-		if bt2 := time.Duration(o.BackfillTolerancePoints) * trq.Step; bt2 > bt {
-			bt = bt2
-		}
-	}
-	bt = trq.GetBackfillTolerance(bt)      // set any query override for backfull tolerance
+	bt := trq.GetBackfillTolerance(o.BackfillTolerance, o.BackfillTolerancePoints)
 	bfs := now.Add(-bt).Truncate(trq.Step) // start of the backfill tolerance window
 
 	OldestRetainedTimestamp := time.Time{}

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -400,7 +400,7 @@ checkCache:
 			shouldCompress = true
 		}
 
-		// if any changes happend to the volatile list, set it in the cached timeseries
+		// if any changes happened to the volatile list, set it in the cached timeseries
 		if shouldCompress {
 			cts.SetVolatileExtents(ve.Compress(trq.Step))
 		}

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -382,7 +382,7 @@ checkCache:
 		if len(cvr) > 0 {
 			// this updates the timeseries's volatile list to remove anything just fetched that is
 			// older than the current backfill tolerance timestamp; so it is now immutable in cache
-			ve = ve.Remove(cvr)
+			ve = ve.Remove(cvr, trq.Step)
 			shouldCompress = true
 		}
 

--- a/pkg/timeseries/extent.go
+++ b/pkg/timeseries/extent.go
@@ -40,9 +40,29 @@ func (e *Extent) StartsAt(t time.Time) bool {
 	return t.Equal(e.Start)
 }
 
+// StartsAtOrBefore returns true if t is equal or before to the Extent's start time
+func (e *Extent) StartsAtOrBefore(t time.Time) bool {
+	return t.Equal(e.Start) || e.Start.Before(t)
+}
+
+// StartsAtOrAfter returns true if t is equal to or after the Extent's start time
+func (e *Extent) StartsAtOrAfter(t time.Time) bool {
+	return t.Equal(e.Start) || e.Start.After(t)
+}
+
 // EndsAt returns true if t is equal to the Extent's end time
 func (e *Extent) EndsAt(t time.Time) bool {
 	return t.Equal(e.End)
+}
+
+// EndsAtOrBefore returns true if t is equal to or earlier than the Extent's end time
+func (e *Extent) EndsAtOrBefore(t time.Time) bool {
+	return t.Equal(e.End) || e.End.Before(t)
+}
+
+// EndsAtOrAfter returns true if t is equal to or after the Extent's end time
+func (e *Extent) EndsAtOrAfter(t time.Time) bool {
+	return t.Equal(e.End) || e.End.After(t)
 }
 
 // After returns true if the range of the Extent is completely after the provided time

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -169,7 +169,7 @@ func (el ExtentList) Clone() ExtentList {
 // CloneRange returns a perfect copy of the ExtentList, cloning only the
 // Extents in the provided index range (upper-bound exclusive)
 func (el ExtentList) CloneRange(start, end int) ExtentList {
-	if end < start {
+	if end < start || start < 0 || end < 0 {
 		return nil
 	}
 	size := end - start

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -187,8 +187,28 @@ func (el ExtentList) CloneRange(start, end int) ExtentList {
 	return c
 }
 
+// Equal returns true if the provided extent list is identical to the subject list
+func (el ExtentList) Equal(el2 ExtentList) bool {
+	if el2 == nil {
+		return false
+	}
+
+	l := len(el)
+	l2 := len(el2)
+	if l != l2 {
+		return false
+	}
+
+	for i := range el {
+		if el2[i] != el[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Remove removes the provided extent list ranges from the subject extent list
-func (el ExtentList) Remove(r ExtentList) ExtentList {
+func (el ExtentList) Remove(r ExtentList, step time.Duration) ExtentList {
 	if len(r) == 0 {
 		return el
 	}
@@ -197,33 +217,55 @@ func (el ExtentList) Remove(r ExtentList) ExtentList {
 	}
 
 	splices := make(map[int]interface{})
+	spliceIns := make(map[int]Extent)
 	c := el.Clone()
 	for _, rem := range r {
 		for i, ex := range c {
-			if !(ex.Start.After(rem.End)) && !(ex.End.Before(rem.Start)) {
+
+			if rem.End.Before(ex.Start) || rem.Start.After(ex.End) {
+				// removal range is not relevant to this extent
+				continue
+			}
+
+			if rem.StartsAtOrBefore(ex.Start) && rem.EndsAtOrAfter(ex.End) {
 				// removal range end is >= extent.End, and start is <= extent.Start
 				// so the entire range will be spliced out of the list
 				splices[i] = nil
-			} else if !(ex.Start.After(rem.End)) || !(ex.End.Before(rem.Start)) {
-				// removal range has some overlap with the current extent, so size it down
-				if rem.Start.After(ex.Start) {
-					c[i].Start = rem.Start
-				}
-				if rem.End.Before(ex.End) {
-					c[i].End = rem.End
-				}
+				continue
 			}
+
+			// the removal is fully inside of the extent, it must be split into two
+			if rem.Start.After(ex.Start) && rem.End.Before(ex.End) {
+				// the first piece will be inserted back in later
+				spliceIns[i] = Extent{Start: ex.Start, End: rem.Start.Add(-step)}
+				// the existing piece will be adjusted in place
+				c[i].Start = rem.End.Add(step)
+				continue
+			}
+
+			// The removal is attached to only one side of the extent, so the
+			// boundaries can be adjusted
+			if rem.Start.After(ex.Start) {
+				c[i].End = rem.Start.Add(-step)
+			} else if rem.End.Before(ex.End) {
+				c[i].Start = rem.End.Add(step)
+			}
+
 		}
 	}
 
-	// if there are no Extents to completely remove from the slice, just return the edited clone
-	if len(splices) == 0 {
+	// if the clone is final, return it now
+	if len(splices) == 0 && len(spliceIns) == 0 {
 		return c
 	}
 
-	// otherwise, make a version of the list that does not include the splice out indexes
-	r = make(ExtentList, 0, len(r))
+	// otherwise, make a version of the does not include the splice out indexes
+	// and includes any splice-in indexes
+	r = make(ExtentList, 0, len(r)+len(spliceIns))
 	for i, ex := range c {
+		if ex2, ok := spliceIns[i]; ok {
+			r = append(r, ex2)
+		}
 		if _, ok := splices[i]; !ok {
 			r = append(r, ex)
 		}

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -280,6 +280,32 @@ func TestRemove(t *testing.T) {
 				Extent{Start: t1100, End: t1300},
 			},
 		},
+		{ // Case 7 empty removals
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{},
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // Case 8 subject list
+			ExtentList{},
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
 	}
 
 	for i, test := range tests {
@@ -362,6 +388,24 @@ func TestString(t *testing.T) {
 				t.Errorf("got %s expected %s", test.el.String(), test.expected)
 			}
 		})
+	}
+
+}
+
+func TestCloneRange(t *testing.T) {
+
+	el := ExtentList{
+		Extent{Start: t600, End: t900},
+	}
+
+	res := el.CloneRange(-1, -1)
+	if res != nil {
+		t.Error("expected nil result", res)
+	}
+
+	res = el.CloneRange(0, 200)
+	if res != nil {
+		t.Error("expected nil result", res)
 	}
 
 }
@@ -619,6 +663,36 @@ func TestCrop(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestEqual(t *testing.T) {
+
+	el := ExtentList{
+		Extent{Start: t100, End: t200},
+		Extent{Start: t600, End: t900},
+		Extent{Start: t1100, End: t1300},
+	}
+
+	b := el.Equal(nil)
+	if b {
+		t.Error("expected false")
+	}
+
+	b = el.Equal(ExtentList{})
+	if b {
+		t.Error("expected false")
+	}
+
+	el2 := ExtentList{
+		Extent{Start: t101, End: t200},
+		Extent{Start: t600, End: t900},
+		Extent{Start: t1100, End: t1300},
+	}
+
+	b = el.Equal(el2)
+	if b {
+		t.Error("expected false")
+	}
 
 }
 
@@ -804,4 +878,21 @@ func TestCalculateDeltas(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTimestampCount(t *testing.T) {
+
+	el := ExtentList{
+		Extent{Start: t100, End: t200},
+		Extent{Start: t600, End: t900},
+		Extent{},
+		Extent{Start: t1100, End: t1300},
+	}
+
+	const expected int64 = 9
+
+	if v := el.TimestampCount(time.Second * 100); v != expected {
+		t.Errorf("expected %d got %d", expected, v)
+	}
+
 }

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -167,6 +167,132 @@ func TestInsideOf(t *testing.T) {
 
 }
 
+func TestRemove(t *testing.T) {
+
+	step := time.Second * 1
+
+	tests := []struct {
+		el       ExtentList
+		removals ExtentList
+		expected ExtentList
+	}{
+		{ // Case 0 (splice entire line)
+			ExtentList{
+				Extent{Start: t100, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t200},
+			},
+			ExtentList{
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // case 1 (adjust start)
+			ExtentList{
+				Extent{Start: t100, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t100},
+			},
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // case 2 (adjust end)
+			ExtentList{
+				Extent{Start: t100, End: t201},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t201, End: t201},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // case 3 (adjust start and end)
+			ExtentList{
+				Extent{Start: t100, End: t201},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t100},
+				Extent{Start: t201, End: t201},
+			},
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // case 4 (overlap)
+			ExtentList{
+				Extent{Start: t100, End: t201},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t101, End: t200},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t100},
+				Extent{Start: t201, End: t201},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // Case 5 (splice entire line 2)
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t200},
+			},
+			ExtentList{
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+		{ // Case 6 (splice entire line 3)
+			ExtentList{
+				Extent{Start: t101, End: t200},
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+			ExtentList{
+				Extent{Start: t100, End: t201},
+			},
+			ExtentList{
+				Extent{Start: t600, End: t900},
+				Extent{Start: t1100, End: t1300},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			v := test.el.Remove(test.removals, step)
+			if !v.Equal(test.expected) {
+				t.Errorf("expected %v got %v", test.expected, v)
+			}
+		})
+	}
+
+}
+
 func TestOutsideOf(t *testing.T) {
 
 	el := ExtentList{

--- a/pkg/timeseries/extent_test.go
+++ b/pkg/timeseries/extent_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Comcast Cable Communications Management, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package timeseries
+
+import "testing"
+
+func TestStartsAtOrAfter(t *testing.T) {
+
+	e := Extent{Start: t101, End: t200}
+	if !e.StartsAtOrAfter(t100) {
+		t.Error(("expected true"))
+	}
+
+	if e.StartsAtOrAfter(t200) {
+		t.Error(("expected false"))
+	}
+
+}
+
+func TestEndsAtOrBefore(t *testing.T) {
+
+	e := Extent{Start: t101, End: t200}
+	if e.EndsAtOrBefore(t100) {
+		t.Error(("expected false"))
+	}
+
+	if !e.EndsAtOrBefore(t201) {
+		t.Error(("expected true"))
+	}
+
+}
+
+// // StartsAtOrAfter returns true if t is equal to or after the Extent's start time
+// func (e *Extent) StartsAtOrAfter(t time.Time) bool {
+// 	return t.Equal(e.Start) || e.Start.After(t)
+// }
+
+// // EndsAtOrBefore returns true if t is equal to or earlier than the Extent's end time
+// func (e *Extent) EndsAtOrBefore(t time.Time) bool {
+// 	return t.Equal(e.End) || e.End.Before(t)
+// }

--- a/pkg/timeseries/modeler_test.go
+++ b/pkg/timeseries/modeler_test.go
@@ -20,9 +20,6 @@ import "testing"
 
 func TestNewModeler(t *testing.T) {
 
-	// 	// UnmarshalerFunc describes a function that unmarshals a Timeseries
-	// type UnmarshalerFunc func([]byte, *TimeRangeQuery) (Timeseries, error)
-
 	f := func([]byte, *TimeRangeQuery) (Timeseries, error) {
 		return nil, nil
 	}

--- a/pkg/timeseries/modeler_test.go
+++ b/pkg/timeseries/modeler_test.go
@@ -18,34 +18,23 @@ package timeseries
 
 import "testing"
 
-func TestFieldDefinitionClone(t *testing.T) {
+func TestNewModeler(t *testing.T) {
 
-	fd := FieldDefinition{
-		Name:     "test",
-		DataType: FieldDataType(1),
+	// 	// UnmarshalerFunc describes a function that unmarshals a Timeseries
+	// type UnmarshalerFunc func([]byte, *TimeRangeQuery) (Timeseries, error)
+
+	f := func([]byte, *TimeRangeQuery) (Timeseries, error) {
+		return nil, nil
 	}
 
-	fd2 := fd.Clone()
+	m := NewModeler(f, nil, nil, nil, f, nil)
 
-	if fd2 != fd {
-		t.Error("clone mismatch")
+	if m.WireUnmarshaler == nil {
+		t.Error("expected non-nil WireUnmarshaler")
 	}
 
-}
-
-func TestFieldDefinitionString(t *testing.T) {
-
-	fd := FieldDefinitions{
-		FieldDefinition{
-			Name:     "test",
-			DataType: FieldDataType(1),
-		},
-	}
-
-	const expected = `[{"name":"test","type":1,"pos":0,"stype":"","provider1":0}]`
-
-	if fd.String() != expected {
-		t.Errorf("expected `%s` got `%s`", expected, fd.String())
+	if m.CacheUnmarshaler == nil {
+		t.Error("expected non-nil CacheUnmarshaler")
 	}
 
 }

--- a/pkg/timeseries/request_options_test.go
+++ b/pkg/timeseries/request_options_test.go
@@ -16,36 +16,14 @@
 
 package timeseries
 
-import "testing"
+import (
+	"testing"
+)
 
-func TestFieldDefinitionClone(t *testing.T) {
-
-	fd := FieldDefinition{
-		Name:     "test",
-		DataType: FieldDataType(1),
+func TestExtractFastForwardDisabled(t *testing.T) {
+	ro := &RequestOptions{}
+	ro.ExtractFastForwardDisabled("test query trickster-fast-forward:off ")
+	if !ro.FastForwardDisable {
+		t.Error("expected true")
 	}
-
-	fd2 := fd.Clone()
-
-	if fd2 != fd {
-		t.Error("clone mismatch")
-	}
-
-}
-
-func TestFieldDefinitionString(t *testing.T) {
-
-	fd := FieldDefinitions{
-		FieldDefinition{
-			Name:     "test",
-			DataType: FieldDataType(1),
-		},
-	}
-
-	const expected = `[{"name":"test","type":1,"pos":0,"stype":"","provider1":0}]`
-
-	if fd.String() != expected {
-		t.Errorf("expected `%s` got `%s`", expected, fd.String())
-	}
-
 }

--- a/pkg/timeseries/timerangequery.go
+++ b/pkg/timeseries/timerangequery.go
@@ -116,14 +116,22 @@ func (trq *TimeRangeQuery) String() string {
 }
 
 // GetBackfillTolerance will return the backfill tolerance for the query based on the provided
-// default, and any query-specific tolerance directives included in the query comments
-func (trq *TimeRangeQuery) GetBackfillTolerance(def time.Duration) time.Duration {
+// defaults, and any query-specific tolerance directives included in the query comments
+func (trq *TimeRangeQuery) GetBackfillTolerance(def time.Duration, points int) time.Duration {
 	if trq.BackfillTolerance > 0 {
 		return trq.BackfillTolerance
 	}
 	if trq.BackfillTolerance < 0 {
 		return 0
 	}
+
+	if points > 0 {
+		sd := time.Duration(points) * trq.Step
+		if sd > def {
+			return sd
+		}
+	}
+
 	return def
 }
 

--- a/pkg/timeseries/timerangequery_test.go
+++ b/pkg/timeseries/timerangequery_test.go
@@ -98,15 +98,24 @@ func TestGetBackfillTolerance(t *testing.T) {
 	expected := time.Second * 5
 
 	trq := &TimeRangeQuery{Statement: "1234"}
-	i := trq.GetBackfillTolerance(expected)
+	i := trq.GetBackfillTolerance(expected, 0)
 	if i != expected {
 		t.Errorf("expected %s got %s", expected, i)
 	}
 
 	trq.BackfillTolerance = time.Second * 30
-	i = trq.GetBackfillTolerance(expected)
+	i = trq.GetBackfillTolerance(expected, 0)
 	if i == expected {
 		t.Errorf("expected %s got %s", time.Second*30, i)
+	}
+
+	trq.Step = 5 * time.Second
+	trq.BackfillTolerance = 0
+
+	expected = time.Second * 50
+	i = trq.GetBackfillTolerance(time.Second*5, 10)
+	if i != expected {
+		t.Errorf("expected %s got %s", expected, i)
 	}
 
 }

--- a/pkg/timeseries/timerangequery_test.go
+++ b/pkg/timeseries/timerangequery_test.go
@@ -76,9 +76,38 @@ func TestClone(t *testing.T) {
 	u, _ := url.Parse("http://127.0.0.1/")
 	trq := &TimeRangeQuery{Statement: "1234", Extent: Extent{Start: time.Unix(5, 0),
 		End: time.Unix(10, 0)}, Step: time.Duration(5) * time.Second, TemplateURL: u}
+
+	trq.TagFieldDefintions = []FieldDefinition{{}}
+	trq.ValueFieldDefinitions = []FieldDefinition{{}}
+	trq.Labels = map[string]string{"test": "trickster"}
+
 	c := trq.Clone()
 	if !reflect.DeepEqual(trq, c) {
 		t.Errorf("expected %s got %s", trq.String(), c.String())
+	}
+}
+
+func TestSizeTRQ(t *testing.T) {
+
+	u, _ := url.Parse("http://127.0.0.1/")
+	trq := &TimeRangeQuery{Statement: "1234", Extent: Extent{Start: time.Unix(5, 0),
+		End: time.Unix(10, 0)}, Step: time.Duration(5) * time.Second, TemplateURL: u}
+
+	size := trq.Size()
+
+	if size != 119 {
+		t.Errorf("expected %d got %d", 119, size)
+	}
+}
+
+func TestExtractBackfillTolerance(t *testing.T) {
+
+	trq := &TimeRangeQuery{}
+
+	trq.ExtractBackfillTolerance("testing trickster-backfill-tolerance:30 ")
+
+	if trq.BackfillTolerance != time.Second*30 {
+		t.Error("expected 30 got", trq.BackfillTolerance)
 	}
 }
 
@@ -116,6 +145,12 @@ func TestGetBackfillTolerance(t *testing.T) {
 	i = trq.GetBackfillTolerance(time.Second*5, 10)
 	if i != expected {
 		t.Errorf("expected %s got %s", expected, i)
+	}
+
+	trq.BackfillTolerance = -1
+	i = trq.GetBackfillTolerance(time.Second*5, 10)
+	if i != 0 {
+		t.Errorf("expected %d got %d", 0, i)
 	}
 
 }

--- a/pkg/timeseries/timeseries.go
+++ b/pkg/timeseries/timeseries.go
@@ -46,6 +46,12 @@ type Timeseries interface {
 	SetExtents(ExtentList)
 	// Extents should return the list of time Extents having data present in the Timeseries
 	Extents() ExtentList
+	// VolatileExtents should return the list of time Extents in the cached Timeseries
+	// that should be re-fetched
+	VolatileExtents() ExtentList
+	// SetVolatileExtents sets the list of time Extents in the cached Timeseries
+	// that should be re-fetched
+	SetVolatileExtents(ExtentList)
 	// TimeStampCount should return the number of unique timestamps across the timeseries
 	TimestampCount() int64
 	// Step should return the Step Interval of the Timeseries


### PR DESCRIPTION
This patch changes the backfill tolerance pattern, which is used to prevent preliminary real-time data from being cached until it is old enough to be considered final, from an eager load to a lazy load pattern.

The previous implementation would simply not cache data new enough to fall in the backfill tolerance window. As a result, every single real-time request to Trickster for the given Backend would result in a partial cache hit at best, since some data would always be excluded from the cache and need to be fetched. There was no possibility of a Cache Hit for time series requests on backends with a backfill tolerance set.

The new approach improves the methodology by caching the the preliminary data and serving to subsequent requests, so long as the lookup is otherwise a cache hit. once a request is made that has a cache status of partial hit - meaning some data requested by the client, but in a different time range than the preliminary data, needs to be fetched - then the resulting delta proxy request will also include any preliminary data ranges that were part of the client range, so as to refresh them.

In this way, preliminary real-time data are eventually updated to their final values, so long as subsequent real-time requests continue to come through to create qualifying partial hits. This allows backends with backfill tolerance to have a Cache Hit Rate comparable to Backends without a backfill tolerance set, while ensuring preliminary data still gets updated.

Separately, a new option was added called `BackfillTolerancePoints` (in addition to the existing `BackfillToleranceMS`). The new option will calculate an alternate backfill tolerance of `BackfillTolerancePoints * request.StepValue`, and the delta proxy cache will choose whichever tolerance value is greater, based on the query's step value. This way, no matter if a chart is a 1yr look with 1wk steps, or 10m look with a 5s step, backfill tolerance will work proportionately.
