### PR TITLE
add regex matching operation to rules

### DIFF
--- a/pkg/backends/rule/operations_test.go
+++ b/pkg/backends/rule/operations_test.go
@@ -51,6 +51,9 @@ func TestOperations(t *testing.T) {
 		expected          string
 	}{
 		{"string-eq", "test", "test", false, "true"},
+		{"string-rmatch", "/example/writer", "^.*\\/writer.*$", false, "true"},
+		{"string-rmatch", "mytesting", "^.*[test.*$", false, "false"},
+		{"string-rmatch", "mytesting", "^.*tst.*$", false, "false"},
 		{"string-contains", "test", "test", false, "true"},
 		{"string-contains", "test", "foo", false, "false"},
 		{"string-prefix", "test", "t", false, "true"},

--- a/pkg/backends/rule/parse.go
+++ b/pkg/backends/rule/parse.go
@@ -17,14 +17,18 @@
 package rule
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	ro "github.com/tricksterproxy/trickster/pkg/backends/rule/options"
 	"github.com/tricksterproxy/trickster/pkg/proxy/handlers"
 	"github.com/tricksterproxy/trickster/pkg/proxy/request/rewriter"
 )
+
+var ErrInvalidRegularExpression = errors.New("invalid regular expression")
 
 func (c *Client) parseOptions(o *ro.Options, rwi map[string]rewriter.RewriteInstructions) error {
 
@@ -141,6 +145,17 @@ func (c *Client) parseOptions(o *ro.Options, rwi map[string]rewriter.RewriteInst
 		r.evaluatorFunc = r.EvaluateCaseArg
 	} else {
 		r.evaluatorFunc = r.EvaluateOpArg
+	}
+
+	if o.InputType == "rmatch" {
+		if r.operationArg == "" {
+			return ErrInvalidRegularExpression
+		}
+		re, err := regexp.Compile(r.operationArg)
+		if err != nil {
+			return err
+		}
+		compiledRegexes[r.operationArg] = re
 	}
 
 	if len(o.CaseOptions) > 0 {


### PR DESCRIPTION
this patch adds an `rmatch` operation capability to the Rules backend type. Users can provide regex's in the configuration file, which are compiled at startup, to match against HTTP Request parts as a rule compilation.