### PR TITLE
refresh governance docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ If you find a bug in Trickster, please file a detailed report as an Issue. We cu
 
 Likewise, if you have a Feature Request, please file a detailed Issue, explaining the feature's functionality and use cases. Features should be useful to the broader community, so be sure to consider that before filing.
 
-If you find a security vulnerability in Trickster, please contact the [Maintainers](MAINTAINERS.md) directly.
+If you find a security vulnerability in Trickster, please follow the instructions in [SECURITY.MD](./SECURITY.MD).
 
 ## Steps to Contribute
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,119 @@
+# Trickster Governance
+
+## Principles
+
+The Trickster community adheres to the following principles:
+
+- **Open**: Trickster is Open Source Software
+- **Welcoming and respectful**: See [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Transparent and accessible**: Changes to the Trickster organization, Trickster code 
+  repositories, and CNCF related activities (e.g. level, involvement, etc) are done in public.
+- **Merit**: Ideas and contributions are accepted according to their technical merit and alignment with
+  project objectives, scope, and design principles.
+
+## Project Lead
+
+The Trickster project has a project lead.
+
+A project lead in Trickster is
+a single person that has a final say in any decision concerning the Trickster project.
+
+The term of the project lead is one year, with no term limit restriction.
+
+The project lead is elected by Trickster Maintainers
+according to an individual's technical merit to Trickster project.
+
+The current project lead is identified in the [MAINTAINERS](MAINTAINERS.md) file.
+
+The Trickster Maintainers can be contacted via email at <cncf-trickster-maintainers@lists.cncf.io>
+
+## Becoming a Maintainer
+
+Trickster Maintainers are selected by invitation from our community of contributors, based on their
+experience with the project and in what domains help is needed. We also invite anyone to submit
+nominations (including self-nominations) for new Maintainers by emailing <cncf-trickster-maintainers@lists.cncf.io>.
+
+
+## Expectations from Maintainers
+
+Trickster has a fairly relaxed set of expectations from Maintainers. Their role is to help
+advance the project in cooperation with the broader community. To that end, we ask that Maintainers be
+engaged with Issues and Pull Requests as time permits, while being especially responsive to @mentions.
+
+## Changes in Maintainership
+
+If a maintainer cannot fulfill the "Expectations from Maintainers", we will completely understand if they step down.
+Outgoing Maintainers who've made significant contributions to the project will remain in the Maintainers
+file with Emeritus status, unless they decline this designation. Emeritus status is determined by nomination and a
+majority vote of the remaining Maintainers.
+
+The Trickster organization will never forcefully remove a current Maintainer, unless they fail to meet
+the principles of Trickster community, or adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Changes in Project Lead
+
+Changes in project lead or term is initiated by opening a GitHub PR.
+
+Anyone from Trickster community can vote on the PR with either +1 or -1, however only votes from current
+Maintainers (at the time of PR creation) are binding.
+
+The PR should only be opened no earlier than 6 weeks before the end of the project lead's term.
+The PR should be kept open for no less than 4 weeks. The PR can only be merged after the end of the
+last project lead's term, with more +1 than -1 in the binding votes.
+
+When there are conflicting PRs about changes in project lead, the PR with the most binding +1 votes is merged.
+
+The project lead can volunteer to step down.
+
+## Changes in Project Governance
+
+Changes in project governance (GOVERNANCE.md) could be initiated by opening a GitHub PR.
+The PR should only be opened no earlier than 6 weeks before the end of the project lead's term.
+The PR should be kept open for no less than 4 weeks. The PR can only be merged following the same
+voting process as in `Changes in Project Lead`.
+
+## Decision making process
+
+Decisions are built on consensus between Maintainers.
+Proposals and ideas can either be submitted for agreement via a GitHub issue or PR,
+or by sending an email to `cncf-trickster-maintainers@lists.cncf.io`.
+
+In the Trickster project, contributors often have ideas, experiment with those ideas, and end up with a viable PR,
+without without first getting buy-in from the Maintainers. That is fine too - we welcome all contributions. We simply ask that all discussion and decision-making about the contribution is transparent and in the open.
+
+Any disputes between community members should be resolved amicably between the involved parties. 
+If a dispute cannot be decided independently, get a third-party maintainer (e.g. a mutual contact with some background
+on the issue, but not involved in the conflict) to intercede.
+If a dispute still cannot be decided, the project lead has the final say to decide an issue.
+
+All decision-making processes should be transparent so as to adhere to
+the principles of Trickster project. All proposals, ideas, and decisions by Maintainers or the project lead
+should either be part of a GitHub issue or PR, or be sent to `cncf-trickster-maintainers@lists.cncf.io`.
+
+## GitHub Project Administration
+
+The [@tricksterproxy/maintainers](https://github.com/orgs/tricksterproxy/teams/maintainers) team reflects the list of Maintainers.
+
+## Other Projects
+
+While Trickster is a highly-focused project, we are open to accepting sub-projects into the organization.
+Such sub-projects would need to meet the following criteria:
+
+- Must be closely related to the Trickster project:
+  - Supports project artifacts (website, deployments, CI, etc.)
+  - Supplemental tools and files (dashboard templates, mocks, migration assistants, etc.)
+- Must be licensed under the terms of the Apache License v2.0
+
+If you would like to submit a sub-project, contact the Maintainers. Note that by donating your project,
+its sponsorship and ownership of any associated marks are transferred to the Cloud Native Computing Foundation.
+
+## Code of Conduct
+
+The [Trickster Code of Conduct](CODE_OF_CONDUCT.md) simply points to the
+[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+
+## Credits
+
+Sections of this documents have been borrowed from the [Fluentd](https://github.com/fluent/fluentd/blob/master/GOVERNANCE.md),
+[Envoy](https://github.com/envoyproxy/envoy/blob/master/GOVERNANCE.md) and
+[CoreDNS](https://github.com/coredns/coredns/blob/master/GOVERNANCE.md) projects.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -5,7 +5,7 @@
 The Trickster community adheres to the following principles:
 
 - **Open**: Trickster is Open Source Software
-- **Welcoming and respectful**: See [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Welcoming and respectful**: See [Code of Conduct](./CODE_OF_CONDUCT.md).
 - **Transparent and accessible**: Changes to the Trickster organization, Trickster code 
   repositories, and CNCF related activities (e.g. level, involvement, etc) are done in public.
 - **Merit**: Ideas and contributions are accepted according to their technical merit and alignment with
@@ -23,7 +23,7 @@ The term of the project lead is one year, with no term limit restriction.
 The project lead is elected by Trickster Maintainers
 according to an individual's technical merit to Trickster project.
 
-The current project lead is identified in the [MAINTAINERS](MAINTAINERS.md) file.
+The current project lead is identified in the [MAINTAINERS](./MAINTAINERS.md) file.
 
 The Trickster Maintainers can be contacted via email at <cncf-trickster-maintainers@lists.cncf.io>
 
@@ -48,7 +48,7 @@ file with Emeritus status, unless they decline this designation. Emeritus status
 majority vote of the remaining Maintainers.
 
 The Trickster organization will never forcefully remove a current Maintainer, unless they fail to meet
-the principles of Trickster community, or adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
+the principles of Trickster community, or adhere to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
 ## Changes in Project Lead
 
@@ -67,7 +67,7 @@ The project lead can volunteer to step down.
 
 ## Changes in Project Governance
 
-Changes in project governance (GOVERNANCE.md) could be initiated by opening a GitHub PR.
+Changes in project governance (GOVERNANCE.md) should be initiated by opening a GitHub PR.
 The PR should only be opened no earlier than 6 weeks before the end of the project lead's term.
 The PR should be kept open for no less than 4 weeks. The PR can only be merged following the same
 voting process as in `Changes in Project Lead`.
@@ -109,7 +109,7 @@ its sponsorship and ownership of any associated marks are transferred to the Clo
 
 ## Code of Conduct
 
-The [Trickster Code of Conduct](CODE_OF_CONDUCT.md) simply points to the
+The [Trickster Code of Conduct](./CODE_OF_CONDUCT.md) simply points to the
 [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
 ## Credits

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -79,7 +79,7 @@ Proposals and ideas can either be submitted for agreement via a GitHub issue or 
 or by sending an email to `cncf-trickster-maintainers@lists.cncf.io`.
 
 In the Trickster project, contributors often have ideas, experiment with those ideas, and end up with a viable PR,
-without without first getting buy-in from the Maintainers. That is fine too - we welcome all contributions. We simply ask that all discussion and decision-making about the contribution is transparent and in the open.
+without first getting buy-in from the Maintainers. That is fine too - we welcome all contributions. We simply ask that all discussion and decision-making about the contribution is transparent and in the open.
 
 Any disputes between community members should be resolved amicably between the involved parties. 
 If a dispute cannot be decided independently, get a third-party maintainer (e.g. a mutual contact with some background

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,23 @@
-Maintainers of this repository with their focus areas:
+# Trickster Maintainers
 
-* James Ranson <james@ranson.org> @jranson (Virga): Core Functionality
-* Chris Randles <randles.chris@gmail.com> @crandles (Comcast): Core Functionality
-* Adam Ross <adamross1126@gmail.com> @LimitlessEarth (Comcast): Deployment-related matters (Makefile, Dockerfile, Helm Charts, etc)
+## Project Lead
 
+| Name | Contact | Company | Term Expires |
+|---|---|---|---|
+|James Ranson ([@jranson](https://github.com/jranson)) | <james@ranson.org> | Virga | 22/Mar/2022 |
 
-You can tag all reviewers in issues/commits/PR's using the @trickster-reviewers handle.
+## Trickster Project Maintainers
+
+| Name | Contact | Company | Focus Areas|
+|---|---|---|---|
+|James Ranson ([@jranson](https://github.com/jranson)) | <james@ranson.org> | Virga | Core Functionality |
+|Chris Randles ([@crandles](https://github.com/crandles)) | <randles.chris@gmail.com> | Comcast | Core Functionality |
+|Adam Ross ([@LimitlessEarth](https://github.com/LimitlessEarth)) | <adamross1126@gmail.com> | Comcast | Deployment & Artifacts (Makefile, Dockerfile, Helm Charts, etc) |
+
+You can contact the maintainers using the `@tricksterproxy/maintainers` handle in an Issue or PR, or via email at <cncf-trickster-maintainers@lists.cncf.io>.
+
+## Reviewers
+
+Additional community members comprise our Reviewers team, who may review and approve PRs, but otherwise do not maintain the project. Reviewers are generally engaged in a PR by a Maintainer seeking input or binding approval from someone with additional expertise in the PR's technical domain. Refer to the [@tricksterproxy/reviewers](https://github.com/orgs/tricksterproxy/teams/reviewers/members) team for a list of our Reviewers.
+
+You can tag all reviewers in issues/commits/PR's using the `@tricksterproxy/reviewers` handle.

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -1,0 +1,3 @@
+# Security
+
+If you've found a vulnerability or a potential vulnerability in Trickster, please let us know by contacting the Maintainers via email at <cncf-trickster-maintainers@lists.cncf.io>. Note that messages to the Maintainers List are not private. If the vulnerability is sensitive and should be communicated privately, contact the [Project Lead](./MAINTAINERS.md#project-lead) directly.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,7 +15,7 @@ The roadmap for Trickster in 2021 focuses on delivering Trickster versions 2.0 a
   - [ ] Support for InfluxDB 2.0, Flux syntax and querying via Chronograf
   - [ ] Purge object from cache by path or key
   - [ ] Short-term caching of non-timeseries read-only queries (e.g., generic SELECT statements)
-  - [ ] Support Brotli encoding over the wire and as a cache compression format
+  - [x] Support Brotli encoding over the wire and as a cache compression format
   
 - [x] Submit Trickster for CNCF Sandbox Consideration
 
@@ -23,7 +23,7 @@ The roadmap for Trickster in 2021 focuses on delivering Trickster versions 2.0 a
 
 - [ ] Trickster v2.0 GA Release
   - [ ] Documentation overhaul using MkDocs with Release deployment automation
-  - [ ] Migrate integration tests infrastructure from private cloud to AWS and deployed via Terraform
+  - [ ] Migrate integration tests infrastructure as needed to easily integrate with related CNCF projects.
 
 - [ ] Trickster v2.1 Beta Release
   - [ ] Support for ElasticSearch


### PR DESCRIPTION
This PR refreshes the Trickster Project's Governance documents to align with CNCF project principles, and relocates security vulnerability instructions from CONTRIBUTING.md to a separate SECURITY.md document, to address #566 

Additionally, this documents me as the Project Lead and establishes a renewable 1yr term, per the Governance Docs, beginning on 3/22/21 (when Trickster was transferred to CNCF).